### PR TITLE
changes in category 'quarry'

### DIFF
--- a/inc-style/landuse-fill.sty
+++ b/inc-style/landuse-fill.sty
@@ -141,13 +141,19 @@
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
-		<Filter>([landuse] = 'quarry') and ([way_area] &lt; 2000000)</Filter>
+		<Filter>([landuse] = 'quarry') and not (([resource = 'gravel']) or ([resource] = 'aggregate')) and ([way_area] &lt; 2000000)</Filter>
 		<PolygonPatternSymbolizer file="symbols-topo/quarry_z13.png"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom15;
-		<Filter>([landuse] = 'quarry') and ([way_area] &lt; 2000000)</Filter>
+		<Filter>([landuse] = 'quarry') and not (([resource = 'gravel']) or ([resource] = 'aggregate')) and ([way_area] &lt; 2000000)</Filter>
 		<PolygonPatternSymbolizer file="symbols-topo/quarry.png"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom13;
+		&minscale_zoom15;
+		<Filter>([landuse] = 'quarry') and (([resource = 'gravel']) or ([resource] = 'aggregate'))and ([way_area] &lt; 2000000)</Filter>
+		<PolygonPatternSymbolizer file="symbols-topo/scree.png"/>
 	</Rule>
 </Style>


### PR DESCRIPTION
In TKs quarries are differenciated into consolidated and unconsolidated
('Massen-/Lockergestein'). Signature resembles 'scree'. Maybe it makes
sense to set it apart using a line as surrounding.