### PR TITLE
Changed TextSymbolizer font parameters for display of i18n characters 

### DIFF
--- a/mapnik/inc/fontset-settings.xml.inc
+++ b/mapnik/inc/fontset-settings.xml.inc
@@ -1,0 +1,28 @@
+<!--Settings for Mapnik Fonts
+Uncomment the unifont entries if you have that font installed
+in your mapnik fonts dir, and want to use it as a fallback font.
+Mapnik includes this font by default since r1328.
+To see the fonts you have installed with Mapnik do:
+ls `python -c "import mapnik;print mapnik.fontscollectionpath"`-->
+
+<FontSet name="serif-book">
+  <Font face-name="DejaVu Serif Book" />
+  <Font face-name="Unifont Medium" />
+</FontSet>
+<FontSet name="sans-book">
+  <Font face-name="DejaVu Sans Book" />
+  <Font face-name="Unifont Medium" />
+</FontSet>
+<FontSet name="sans-condensed">
+  <Font face-name="DejaVu Sans Condensed" />
+  <Font face-name="Unifont Medium" />
+</FontSet>
+<FontSet name="sans-condensed-bold">
+  <Font face-name="DejaVu Sans Condensed Bold" />
+  <Font face-name="Unifont Medium" />
+</FontSet>
+<FontSet name="sans-oblique">
+  <Font face-name="DejaVu Sans Oblique" />
+  <Font face-name="Unifont Medium" />
+</FontSet>
+

--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -85,6 +85,8 @@
 -->
 <Map background-color="#e0e0e0" srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs +over" buffer-size="256">
 	<!-- style definitions -->
+	&fontset-settings;
+
 	&landuse-lowzoom;
 	&landuse;
 	&landuse-over-hillshade;

--- a/mapnik/styles-otm/admin_centers.xml
+++ b/mapnik/styles-otm/admin_centers.xml
@@ -2,9 +2,9 @@
 	<Rule>
 		&maxscale_zoom8;
 		&minscale_zoom17;
-		<!--<TextSymbolizer face-name="DejaVu Sans Book" size="10" placement="point" fill="red" allow-overlap="false">o</TextSymbolizer>-->
+		<!--<TextSymbolizer fontset-name="sans-book" size="10" placement="point" fill="red" allow-overlap="false">o</TextSymbolizer>-->
 		<PointSymbolizer file="symbols-otm/town_z8.png" allow-overlap="false" />
-		<TextSymbolizer face-name="DejaVu Sans Book" size="11" fill="black" placement="point" halo-radius="2" halo-fill="rgba(255,255,255,0.5)" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-book" size="11" fill="black" placement="point" halo-radius="2" halo-fill="rgba(255,255,255,0.5)" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />

--- a/mapnik/styles-otm/contours.xml
+++ b/mapnik/styles-otm/contours.xml
@@ -34,7 +34,7 @@
 		&maxscale_zoom11;
 		&minscale_zoom14;
 		<Filter>([height] % 100 = 0) and ([height] != 0)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Book" size="7" fill="#bc7e55" halo-radius="1" halo-fill="rgba(255,255,255,1)" halo-comp-op="soft-light" placement="line" max-char-angle-delta="10" label-position-tolerance="100" minimum-path-length="200" spacing="200">[height]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-book" size="7" fill="#bc7e55" halo-radius="1" halo-fill="rgba(255,255,255,1)" halo-comp-op="soft-light" placement="line" max-char-angle-delta="10" label-position-tolerance="100" minimum-path-length="200" spacing="200">[height]</TextSymbolizer>
 	</Rule>
 
 	<!-- 50 m -->
@@ -60,7 +60,7 @@
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([height] % 100 != 0) and ([height] % 50 = 0) and ([height] != 0)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Book" size="7" fill="#bc7e55" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" halo-comp-op="soft-light" placement="line" max-char-angle-delta="10" label-position-tolerance="100" minimum-path-length="200" spacing="200">[height]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-book" size="7" fill="#bc7e55" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" halo-comp-op="soft-light" placement="line" max-char-angle-delta="10" label-position-tolerance="100" minimum-path-length="200" spacing="200">[height]</TextSymbolizer>
 	</Rule>
 
 	<!-- 20 m -->
@@ -82,6 +82,6 @@
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([height] % 10 = 0) and ([height] != 0)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Book" size="7" fill="#bc7e55" halo-radius="1" halo-fill="rgba(255,255,255,0.3)" placement="line" max-char-angle-delta="10" label-position-tolerance="100" minimum-path-length="300" spacing="800">[height]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-book" size="7" fill="#bc7e55" halo-radius="1" halo-fill="rgba(255,255,255,0.3)" placement="line" max-char-angle-delta="10" label-position-tolerance="100" minimum-path-length="300" spacing="800">[height]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/housenumbers.xml
+++ b/mapnik/styles-otm/housenumbers.xml
@@ -2,6 +2,6 @@
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.6)" placement="point">[addr:housenumber]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.6)" placement="point">[addr:housenumber]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/motorway_junctions.xml
+++ b/mapnik/styles-otm/motorway_junctions.xml
@@ -4,6 +4,6 @@
 	<Rule>
 		&maxscale_zoom10;
 		&minscale_zoom10;
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="red" halo-radius="2" halo-fill="rgba(255,255,255,1)" placement="point">o</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="red" halo-radius="2" halo-fill="rgba(255,255,255,1)" placement="point">o</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/road-names-text.xml
+++ b/mapnik/styles-otm/road-names-text.xml
@@ -5,13 +5,13 @@
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>[highway] = 'motorway' or [highway] = 'trunk' or [highway] = 'primary'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,181,72,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,181,72,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>[highway] = 'secondary'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,253,79,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,253,79,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
 	</Rule>
 
 	<!-- zoom 16 -->
@@ -19,19 +19,19 @@
 		&maxscale_zoom16;
 		&minscale_zoom16;
 		<Filter>[highway] = 'motorway' or [highway] = 'trunk' or [highway] = 'primary' or [highway] = 'motorway_link' or [highway] = 'trunk_link' or [highway] = 'primary_link'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,181,72,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,181,72,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom16;
 		<Filter>[highway] = 'secondary' or [highway] = 'tertiary' or [highway] = 'secondary_link' or [highway] = 'tertiary_link'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,253,79,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,253,79,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom16;
 		<ElseFilter/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.5)" repeat-distance="250" placement="line">[name]</TextSymbolizer>
 	</Rule>
 
 	
@@ -40,18 +40,18 @@
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<Filter>[highway] = 'motorway' or [highway] = 'trunk' or [highway] = 'primary' or [highway] = 'motorway_link' or [highway] = 'trunk_link' or [highway] = 'primary_link'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,181,72,0.7)" repeat-distance="250" character-spacing="1" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,181,72,0.7)" repeat-distance="250" character-spacing="1" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<Filter>[highway] = 'secondary' or [highway] = 'tertiary' or [highway] = 'secondary_link' or [highway] = 'tertiary_link'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,253,79,0.7)" repeat-distance="150" character-spacing="1" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(253,253,79,0.7)" repeat-distance="150" character-spacing="1" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<ElseFilter/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" repeat-distance="150" character-spacing="1" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" repeat-distance="150" character-spacing="1" placement="line">[name]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/symbols-1.xml
+++ b/mapnik/styles-otm/symbols-1.xml
@@ -30,7 +30,7 @@
 		&minscale_zoom17;
 		<Filter>
 (([historic] = 'castle') and (([castle_type] = 'fortress') or ([castle_type] = 'defensive') or ([castle_type] = 'burg') or ([castle_type] = 'festung')))</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="4">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="4">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
@@ -43,7 +43,7 @@
 		&maxscale_zoom14;
 		&minscale_zoom17;
 		<Filter>(([historic] = 'castle') and not (([castle_type] = 'fortress') or ([castle_type] = 'defensive') or ([castle_type] = 'burg') or ([castle_type] = 'festung')))</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="4">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="4">[name]</TextSymbolizer>
 	</Rule>
 -->
  
@@ -64,7 +64,7 @@
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>[amenity] = 'place_of_worship' and [religion] = 'christian' and ([denomination] = NULL or [denomination] = 'catholic' or [denomination] = 'roman_catholic' or [denomination] = 'greek_catholic' or [denomination] = 'lutheran' or [denomination] = 'protestant') and not (([building] = 'chapel') or ([building] = 'wayside_chapel') or ([historic] = 'wayside_chapel'))</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.9)" placement="point" dy="6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.9)" placement="point" dy="6">[name]</TextSymbolizer>
 	</Rule>
 	
 	<Rule>
@@ -115,7 +115,7 @@
 		<Filter>(([historic] = 'ruins') or
 (([ruins] = 'yes') and (([historic] = 'castle') and (([castle_type] = 'fortress') or ([castle_type] = 'defensive') or ([castle_type] = 'burg') or ([castle_type] = 'festung'))))) or
 		(([ruins] = 'yes') and (([historic] = 'castle') and not (([castle_type] = 'fortress') or ([castle_type] = 'defensive') or ([castle_type] = 'burg') or ([castle_type] = 'festung'))))</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="4">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="4">[name]</TextSymbolizer>
 	</Rule>
 -->
 </Style>

--- a/mapnik/styles-otm/symbols-2.xml
+++ b/mapnik/styles-otm/symbols-2.xml
@@ -42,7 +42,7 @@
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>( ([man_made] = 'tower') and (([tower:type] = 'observation') or ([tourism] = 'viewpoint')))</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="1" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="9">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="1" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="9">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
@@ -55,7 +55,7 @@
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([man_made] = 'communications_tower') or ([communication:radio] = 'yes') or ([communication:television] = 'yes')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="1" halo-fill="rgba(255,255,255,0.9)" placement="point" dy="8">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="1" halo-fill="rgba(255,255,255,0.9)" placement="point" dy="8">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
@@ -101,7 +101,7 @@
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([man_made] = 'water_tower')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="7" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="5">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="7" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="5">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
@@ -126,7 +126,7 @@
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([natural] = 'cave_entrance')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="6">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
@@ -207,7 +207,7 @@
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>([railway] = 'station')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="#5427ff" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="#5427ff" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="6">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
@@ -233,14 +233,14 @@
 		&minscale_zoom17;
  		<Filter>[tourism] = 'alpine_hut'</Filter>
 		<PointSymbolizer file="symbols-otm/hut_alpine.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="6">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom17;
  		<Filter>[tourism] = 'wilderness_hut'</Filter>
 		<PointSymbolizer file="symbols-otm/hut_wilderness.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.7)" placement="point" dy="6">[name]</TextSymbolizer>
 	</Rule>
 	
 	<Rule>
@@ -269,7 +269,7 @@
 		&minscale_zoom17;
  		<Filter>([amenity] = 'hospital') </Filter>
 		<PointSymbolizer file="symbols-otm/hospital.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="6">[name]</TextSymbolizer>
 	</Rule>
 
 <!--	<Rule>

--- a/mapnik/styles-otm/text-cities-lowzoom.xml
+++ b/mapnik/styles-otm/text-cities-lowzoom.xml
@@ -4,7 +4,7 @@
 		&minscale_zoom3;
 		<Filter>([capital] = 'yes' and [admin_level] = '2' and [population] &gt; 500E3)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small2.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="1" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="1" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dy="4" />
 			<Placement dx="4" dy="-3" />
 			<Placement dx="4" dy="3" />
@@ -16,7 +16,7 @@
 		&minscale_zoom4;
 		<Filter>([capital] = 'yes' and [admin_level] = '2' and [population] &gt; 200E3)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small2.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="10" fill="black" halo-radius="1" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="10" fill="black" halo-radius="1" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dy="4" />
 			<Placement dx="4" dy="-3" />
 			<Placement dx="4" dy="3" />
@@ -28,7 +28,7 @@
 		&minscale_zoom5;
 		<Filter>([capital] = 'yes' and [admin_level] = '2' and [population] &gt; 100E3)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="12" fill="black" halo-radius="2" wrap-width="100" placement="point" text-transform="uppercase" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="12" fill="black" halo-radius="2" wrap-width="100" placement="point" text-transform="uppercase" placement-type="list">[name]
 			<Placement dx="5" dy="-4" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="7" />
@@ -40,21 +40,21 @@
 		&minscale_zoom6;
 		<Filter>([capital] = 'yes' and [admin_level] = '2')</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="12" fill="black" halo-radius="2" wrap-width="100" placement="point" dx="5" dy="-3" text-transform="uppercase">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="12" fill="black" halo-radius="2" wrap-width="100" placement="point" dx="5" dy="-3" text-transform="uppercase">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom7;
 		&minscale_zoom7;
 		<Filter>([capital] = 'yes' and [admin_level] = '2')</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="13" fill="black" halo-radius="2" wrap-width="100" placement="point" dx="5" dy="-3" text-transform="uppercase">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="13" fill="black" halo-radius="2" wrap-width="100" placement="point" dx="5" dy="-3" text-transform="uppercase">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom8;
 		&minscale_zoom8;
 		<Filter>([capital] = 'yes' and [admin_level] = '2')</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="15" fill="black" halo-radius="2" wrap-width="100" placement="point" dx="5" dy="-3" text-transform="uppercase">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="15" fill="black" halo-radius="2" wrap-width="100" placement="point" dx="5" dy="-3" text-transform="uppercase">[name]</TextSymbolizer>
 	</Rule>
 
 
@@ -64,7 +64,7 @@
 		&minscale_zoom4;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &gt; 1E6)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small2.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="1" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="1" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dy="4" />
 			<Placement dx="4" dy="-3" />
 			<Placement dx="4" dy="3" />
@@ -76,7 +76,7 @@
 		&minscale_zoom5;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &gt; 1E6)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />
@@ -88,7 +88,7 @@
 		&minscale_zoom5;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &lt; 1E6) and ([population] &gt; 250E3)</Filter>
 		<PointSymbolizer file="symbols-otm/town_z8.png" />
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />
@@ -105,7 +105,7 @@
 		&minscale_zoom6;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &gt; 1E6)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed Bold" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed-bold" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />
@@ -119,7 +119,7 @@
 		&minscale_zoom6;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &lt; 1E6) and ([population] &gt; 400E3)</Filter>
 		<PointSymbolizer file="symbols-otm/town_z8.png" />
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />
@@ -133,7 +133,7 @@
 		&minscale_zoom6;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ((([population] &lt; 400E3) and ([population] &gt; 100E3)) or [population] = null)</Filter>
 		<PointSymbolizer file="symbols-otm/town_z8.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />
@@ -150,7 +150,7 @@
 		&minscale_zoom7;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &gt; 1E6)</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="4" dy="-3" />
 			<Placement dx="4" dy="3" />
 			<Placement dy="4" />
@@ -164,7 +164,7 @@
 		&minscale_zoom7;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &lt; 1E6) and ([population] &gt; 100E3)</Filter>
 		<PointSymbolizer file="symbols-otm/city_small.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="5" />
@@ -178,7 +178,7 @@
 		&minscale_zoom7;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &lt; 100E3 or [population] = null)</Filter>
 		<PointSymbolizer file="symbols-otm/town_z8.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="11" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="11" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="4" dy="-2" />
 			<Placement dx="4" dy="2" />
 			<Placement dy="4" />
@@ -193,7 +193,7 @@
 		&minscale_zoom8;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &gt; 1E6)</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="4" dy="-3" />
 			<Placement dx="4" dy="3" />
 			<Placement dy="4" />
@@ -207,7 +207,7 @@
 		&minscale_zoom8;
 		<Filter>(([place] = 'city') and not ([capital] = 'yes')) and ([population] &lt; 1E6 or [population] = null)</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-4" />
 			<Placement dx="5" dy="4" />
 			<Placement dy="5" />

--- a/mapnik/styles-otm/text-cities.xml
+++ b/mapnik/styles-otm/text-cities.xml
@@ -5,31 +5,31 @@
 		&minscale_zoom9;
 		<Filter>([place] = 'city')</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="10" dy="-5">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="10" dy="-5">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom10;
 		&minscale_zoom10;
 		<Filter>([place] = 'city')</Filter>
 		<PointSymbolizer file="symbols-otm/city.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="17" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="11" dy="-6">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="17" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="11" dy="-6">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([place] = 'city')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="20" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-3">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="20" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-3">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'city')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="20" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="75" dy="-5">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="20" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="75" dy="-5">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'city')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" justify-alignment="center" dx="75" placement="point" size="23" dy="-5">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" justify-alignment="center" dx="75" placement="point" size="23" dy="-5">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-natural-line.xml
+++ b/mapnik/styles-otm/text-natural-line.xml
@@ -3,18 +3,18 @@
 		&maxscale_zoom11;
 		&minscale_zoom12;
 		<Filter>[natural] = 'ridge' or [natural] = 'valley' or [natural] = 'gorge'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="line" spacing="500" allow-overlap="true" character-spacing="10">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="line" spacing="500" allow-overlap="true" character-spacing="10">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom15;
 		<Filter>[natural] = 'ridge' or [natural] = 'valley' or [natural] = 'gorge'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="line" spacing="500" allow-overlap="true" character-spacing="30">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="line" spacing="500" allow-overlap="true" character-spacing="30">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>[natural] = 'ridge' or [natural] = 'valley' or [natural] = 'gorge'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="line" spacing="700" allow-overlap="true" character-spacing="50">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="line" spacing="700" allow-overlap="true" character-spacing="50">[name]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-natural-point.xml
+++ b/mapnik/styles-otm/text-natural-point.xml
@@ -3,19 +3,19 @@
 		&maxscale_zoom13;
 		&minscale_zoom17;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and ([name] = null)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="3">[ele]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="3">[ele]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and not ([name] = null)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="3">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="3">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom17;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and not ([name] = null)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="3">[name]</TextSymbolizer>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="13">[ele]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="3">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="grey" halo-comp-op="screen" placement="point" dy="13">[ele]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-natural-poly-lowzoom.xml
+++ b/mapnik/styles-otm/text-natural-poly-lowzoom.xml
@@ -3,54 +3,54 @@
 		&maxscale_zoom5;
 		&minscale_zoom5;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 1E11</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom6;
 		&minscale_zoom7;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 1E10</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom8;
 		&minscale_zoom10;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 1100000000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 1100000000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="14" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="14" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 50000000 and [way_area] &lt; 1100000000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 50000000</Filter>
-	<TextSymbolizer face-name="DejaVu Sans Oblique" size="14" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+	<TextSymbolizer fontset-name="sans-oblique" size="14" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 5000000 and [way_area] &lt; 50000000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="11" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="11" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 50000000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="17" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="17" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([natural] = 'water' or [water] ='lake') and [way_area] &gt; 5000000 and [way_area] &lt; 50000000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="11" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="11" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-natural-poly.xml
+++ b/mapnik/styles-otm/text-natural-poly.xml
@@ -3,18 +3,18 @@
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>[natural] = 'water' and [way_area] &gt; 500000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>[natural] = 'water' and [way_area] &gt; 50000</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>[natural] = 'water'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="interior">[name]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-roads-ref.xml
+++ b/mapnik/styles-otm/text-roads-ref.xml
@@ -3,30 +3,30 @@
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>[highway] = 'motorway' or [highway] = 'trunk'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="11" fill="black" spacing="500" minimum-distance="500" minimum-path-length="60" minimum-padding="60" dy="5" halo-radius="1" placement="line">[ref]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="11" fill="black" spacing="500" minimum-distance="500" minimum-path-length="60" minimum-padding="60" dy="5" halo-radius="1" placement="line">[ref]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom13;
 		<Filter>[highway] = 'motorway' or [highway] = 'trunk'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" spacing="400" minimum-distance="400" minimum-path-length="50" minimum-padding="50" dy="5" halo-radius="1" placement="line">[ref]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" spacing="400" minimum-distance="400" minimum-path-length="50" minimum-padding="50" dy="5" halo-radius="1" placement="line">[ref]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>[highway] = 'primary'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" spacing="400" minimum-distance="400" minimum-path-length="50" minimum-padding="50" dy="4" halo-radius="1" placement="line">[ref]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" spacing="400" minimum-distance="400" minimum-path-length="50" minimum-padding="50" dy="4" halo-radius="1" placement="line">[ref]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom17;
 		<Filter>[highway] = 'primary' or [highway] = 'secondary'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" spacing="400" minimum-path-length="50" minimum-padding="50" repeat-distance="400" dy="5" halo-radius="1" placement="line" margin="50" rotate-displacement="true">[ref]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" spacing="400" minimum-path-length="50" minimum-padding="50" repeat-distance="400" dy="5" halo-radius="1" placement="line" margin="50" rotate-displacement="true">[ref]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom17;
 		<Filter>[highway] = 'motorway' or [highway] = 'trunk'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" spacing="400" minimum-path-length="50" minimum-padding="50" repeat-distance="400" dy="8" halo-radius="1" placement="line" margin="50">[ref]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" spacing="400" minimum-path-length="50" minimum-padding="50" repeat-distance="400" dy="8" halo-radius="1" placement="line" margin="50">[ref]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-states.xml
+++ b/mapnik/styles-otm/text-states.xml
@@ -2,7 +2,7 @@
 	<Rule>
 		&maxscale_zoom5;
 		&minscale_zoom7;
-		<TextSymbolizer face-name="DejaVu Sans Book" size="12" fill="#c82fe5" placement="point" character-spacing="3" halo-radius="2" halo-fill="rgba(255,255,255,0.5)">[name]
+		<TextSymbolizer fontset-name="sans-book" size="12" fill="#c82fe5" placement="point" character-spacing="3" halo-radius="2" halo-fill="rgba(255,255,255,0.5)">[name]
 		</TextSymbolizer>
 	</Rule>
 

--- a/mapnik/styles-otm/text-towns.xml
+++ b/mapnik/styles-otm/text-towns.xml
@@ -5,7 +5,7 @@
 		&minscale_zoom7;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
 		<PointSymbolizer file="symbols-otm/town_z8.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="70" wrap-before="true" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="70" wrap-before="true" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="-6" />
@@ -20,7 +20,7 @@
 		&minscale_zoom8;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
 		<PointSymbolizer file="symbols-otm/town_z8.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="75" wrap-before="true" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="75" wrap-before="true" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="-6" />
@@ -35,7 +35,7 @@
 		&minscale_zoom9;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
 		<PointSymbolizer file="symbols-otm/town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="80" wrap-before="true" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="80" wrap-before="true" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="-6" />
@@ -48,7 +48,7 @@
 		&minscale_zoom9;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
 		<PointSymbolizer file="symbols-otm/town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="80" wrap-before="true" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="80" wrap-before="true" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-3" />
 			<Placement dx="4" dy="3" />
 			<Placement dy="-6" />
@@ -63,7 +63,7 @@
 		&minscale_zoom10;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
 		<PointSymbolizer file="symbols-otm/town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="7" dy="-5" />
 			<Placement dx="7" dy="5" />
 			<Placement dy="-8" />
@@ -76,7 +76,7 @@
 		&minscale_zoom10;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
 		<PointSymbolizer file="symbols-otm/town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="80" wrap-before="true" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="80" wrap-before="true" placement="point" placement-type="list">[name]
 			<Placement dx="6" dy="-4" />
 			<Placement dx="6" dy="4" />
 			<Placement dy="-7" />
@@ -89,7 +89,7 @@
 		&minscale_zoom10;
 		<Filter>([place] = 'town') and ([population] &lt; 10000) and ([population] &gt; 5000)</Filter>
 		<PointSymbolizer file="symbols-otm/small_town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="75" wrap-before="true" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="75" wrap-before="true" placement="point" placement-type="list">[name]
 			<Placement dx="4" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="-6" />
@@ -104,7 +104,7 @@
 		&minscale_zoom11;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
 		<PointSymbolizer file="symbols-otm/town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="16" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="16" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="6" dy="-5" />
 			<Placement dx="7" dy="5" />
 			<Placement dy="-8" />
@@ -117,7 +117,7 @@
 		&minscale_zoom11;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
 		<PointSymbolizer file="symbols-otm/town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="5" dy="-4" />
 			<Placement dx="6" dy="4" />
 			<Placement dy="-7" />
@@ -130,7 +130,7 @@
 		&minscale_zoom11;
 		<Filter>([place] = 'town') and not ([population] &gt; 10000)</Filter>
 		<PointSymbolizer file="symbols-otm/small_town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="11" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="11" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" placement-type="list">[name]
 			<Placement dx="4" dy="-3" />
 			<Placement dx="5" dy="3" />
 			<Placement dy="-6" />
@@ -144,7 +144,7 @@
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="18" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" dx="40" dy="-4" justify-alignment="center" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="18" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" dx="40" dy="-4" justify-alignment="center" placement="point" placement-type="list">[name]
 			<Placement dx="40" dy="-5" />
 			<Placement dx="7" dy="5" />
 			<Placement dy="-8" />
@@ -156,7 +156,7 @@
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" dx="40" dy="-4" justify-alignment="center" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" dx="40" dy="-4" justify-alignment="center" placement="point" placement-type="list">[name]
 			<Placement dx="40" dy="-4" />
 			<Placement dx="7" dy="5" />
 			<Placement dy="-8" />
@@ -168,7 +168,7 @@
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'town') and not ([population] &gt; 10000)</Filter>	
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" dx="30" dy="-3" justify-alignment="center" placement="point" placement-type="list">[name]
+		<TextSymbolizer fontset-name="sans-condensed" size="14" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" dx="30" dy="-3" justify-alignment="center" placement="point" placement-type="list">[name]
 			<Placement dx="30" dy="-3" />
 			<Placement dx="7" dy="5" />
 			<Placement dy="-8" />
@@ -182,56 +182,56 @@
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="18" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="40" dy="-5" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="18" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="40" dy="-5" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="17" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="30" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="17" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="30" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'town') and not ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="16" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="16" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="19" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="40" dy="-5" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="19" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="40" dy="-5" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="18" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="30" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="18" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="30" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'town') and not ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="16" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="16" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-4" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>([place] = 'town') and ([population] &gt; 50000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="33" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="15" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="33" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="15" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>([place] = 'town') and ([population] &lt; 50000) and ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="30" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="15" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="30" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="15" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>([place] = 'town') and not ([population] &gt; 10000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="25" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="10" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="25" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="10" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-villages.xml
+++ b/mapnik/styles-otm/text-villages.xml
@@ -5,7 +5,7 @@
 		&minscale_zoom11;
 		<Filter>([place] = 'village') and ([population] &gt; 1000)</Filter>
 		<PointSymbolizer file="symbols-otm/small_town.png"/>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="4" dy="-3">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="4" dy="-3">[name]</TextSymbolizer>
 	</Rule>
 
 
@@ -14,19 +14,19 @@
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'village') and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="4" dy="-3">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="4" dy="-3">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'village') and not ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="4" dy="-3">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="4" dy="-3">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([place] = 'suburb') and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" >[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" >[name]</TextSymbolizer>
 	</Rule>
 
 
@@ -35,25 +35,25 @@
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'village') and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="20" dy="-5">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="20" dy="-5">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'village') and not ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" opacity="0.9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="10" dy="-4">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" opacity="0.9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="10" dy="-4">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'suburb') and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([place] = 'suburb') and not ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="12" opacity="0.9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="12" opacity="0.9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 
 
@@ -62,33 +62,33 @@
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'village') and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-7" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="50" dy="-7" justify-alignment="center">[name] + "\n" <Format size="10">[ele]</Format></TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'village') and not ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="25" dy="-7">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="25" dy="-7">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>(([place] = 'suburb') or ([place] = 'neighbourhood')) and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'suburb') and not ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="13" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([place] = 'hamlet' or [place] = 'isolated_dwelling')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="13" dy="-7">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="10" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point" dx="13" dy="-7">[name]</TextSymbolizer>
 	</Rule>
 
 <!-- zoom 15-17 -->
@@ -96,25 +96,25 @@
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>(([place] = 'village') or ([place] = 'suburb') or ([place] = 'neighbourhood')) and ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="17" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="5" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="17" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="5" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>(([place] = 'village') or ([place] = 'suburb') or ([place] = 'neighbourhood')) and not ([population] &gt; 1000)</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="5" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="15" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" character-spacing="5" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([place] = 'hamlet' or [place] = 'isolated_dwelling')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Condensed" size="11" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" dx="20" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-condensed" size="11" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" dx="20" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([place] = 'locality')</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="black" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="black" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" wrap-width="100" placement="point">[name]</TextSymbolizer>
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/text-waterways.xml
+++ b/mapnik/styles-otm/text-waterways.xml
@@ -3,25 +3,25 @@
 		&maxscale_zoom14;
 		&minscale_zoom15;
 		<Filter>[waterway] = 'river'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="2" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="2" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>[waterway] = 'river'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="11" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="8" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="11" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="8" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom16;
 		<Filter>[waterway] = 'stream'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="9" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="2" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="2" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<Filter>[waterway] = 'stream'</Filter>
-		<TextSymbolizer face-name="DejaVu Sans Oblique" size="10" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="3" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="10" fill="#2020ff" spacing="700" minimum-distance="250" minimum-path-length="200" max-char-angle-delta="30" dy="3" halo-radius="1" halo-fill="rgba(255,255,255,0.8)" placement="line">[name]</TextSymbolizer>
 	</Rule>
 </Style>


### PR DESCRIPTION
Opentopomap shows boxes instead of chinese characters, probably because the DejaVu fonts don't include them. Possible solution:
* define fontsets in "fontset-settings.xml.inc", with "Unifont Medium" as fallback
* replace all TextSymbolizer "face-name" parameters by their "fontset-name" counterparts
