### PR TITLE
Render aeroway=* as area

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -56,6 +56,7 @@
 	<!ENTITY bridges-fill SYSTEM "styles-otm/bridges-fill.xml">
 	<!ENTITY bridges-middle SYSTEM "styles-otm/bridges-middle.xml">
 	<!ENTITY aerialways SYSTEM "styles-otm/aerialways.xml">
+	<!ENTITY aeroways-areas SYSTEM "styles-otm/aeroways-areas.xml">
 	<!ENTITY powerlines SYSTEM "styles-otm/powerlines.xml">
 	<!ENTITY powertowers SYSTEM "styles-otm/powertowers.xml">
 	<!ENTITY text-natural-line SYSTEM "styles-otm/text-natural-line.xml">
@@ -134,6 +135,7 @@
 	&bridges-fill;
 	&bridges-middle;
 	&aerialways;
+        &aeroways-areas;
 	&powerlines;
 	&powertowers;
 	&text-natural-line;
@@ -366,6 +368,16 @@
 			&postgis-settings;
 		</Datasource>
 	</Layer>
+
+	<Layer name="aerowaysareas">
+		<StyleName>aeroways-areas</StyleName>
+		<Datasource>
+			<Parameter name="table">(SELECT way,aeroway,way_area FROM planet_osm_polygon WHERE aeroway IS NOT NULL) AS aeroareas</Parameter>
+			<Parameter name="dbname">gis</Parameter>
+			&postgis-settings;
+		</Datasource>
+	</Layer>
+
 	
 	<Layer name="roads-lowzoom">
 		<StyleName>roads-casing-lowzoom</StyleName>
@@ -472,6 +484,9 @@
 			&postgis-settings;
 		</Datasource>
 	</Layer>
+
+
+
 	
 	<Layer name="powerlines">
 		<StyleName>powerlines</StyleName>

--- a/mapnik/styles-otm/aeroways-areas.xml
+++ b/mapnik/styles-otm/aeroways-areas.xml
@@ -1,0 +1,22 @@
+<Style name="aeroways-areas">
+
+<!-- aeroway areas -->
+	
+	<Rule>
+		&maxscale_zoom12;
+		&minscale_zoom13;
+		<Filter> ([aeroway] = 'apron' or [aeroway] = 'helipad' or [aeroway] = 'runway' or [aeroway] = 'taxilane' or [aeroway] = 'taxiway' ) and ([way_area] &gt; 10000)</Filter>
+		<PolygonSymbolizer fill="#999999" />
+		<LineSymbolizer stroke="#cccccc" stroke-width="0.25" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom17;
+		<Filter> [aeroway] = 'apron' or [aeroway] = 'helipad' or [aeroway] = 'runway' or [aeroway] = 'taxilane' or [aeroway] = 'taxiway'</Filter>
+		<PolygonSymbolizer fill="#dddddd" />
+		<LineSymbolizer stroke="black" stroke-width="0.5" />
+	</Rule>
+
+
+</Style>

--- a/mapnik/styles-otm/airports-casing.xml
+++ b/mapnik/styles-otm/airports-casing.xml
@@ -3,54 +3,54 @@
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="#666666" stroke-width="2" stroke-linecap="square" />
+		<LineSymbolizer stroke="#666666" stroke-width="2" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="3.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="3.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="3.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="3.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="5" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="6" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="6" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="9.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="9.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="#666666" stroke-width="1" stroke-linecap="square" />
+		<LineSymbolizer stroke="#666666" stroke-width="1" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom13;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="2" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="2" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="black" stroke-width="4" stroke-linecap="square" />
+		<LineSymbolizer stroke="black" stroke-width="4" stroke-linecap="butt" />
 	</Rule>
 </Style>

--- a/mapnik/styles-otm/airports-fill.xml
+++ b/mapnik/styles-otm/airports-fill.xml
@@ -3,60 +3,60 @@
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="1" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="1" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="2.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="2.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="2.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="2.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="4" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="4" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="4.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="4.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([aeroway] = 'runway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="8" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="8" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="0.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="0.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="1.5" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="1.5" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="1.3" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="1.3" stroke-linecap="butt" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
 		<Filter>([aeroway] = 'taxiway')</Filter>
-		<LineSymbolizer stroke="#dddddd" stroke-width="3" stroke-linecap="square" />
+		<LineSymbolizer stroke="#dddddd" stroke-width="3" stroke-linecap="butt" />
 	</Rule>
 </Style>


### PR DESCRIPTION
patch for #85

Changed  the linecap of aeroway-lines to avoid situations like [in Schönberg](http://www.openstreetmap.org/#map=17/48.04723/12.49967). The line is covered by an area with the same length. With linecap=square the line gets longer and we see it under the area:
![Line under area](http://geo.dianacht.de/bilder/aeroway_way_under_area.png)

As a disadvantage now the strokes at the end of lines are missing[ in Königsdorf](http://www.openstreetmap.org/#map=18/47.82901/11.45950):
[missing strokes](http://geo.dianacht.de/bilder/aeroway_butt.png)

There is no difference between runway, taxiway, taxline and apron (in osm carto aprons are rendered different, like [in Salzburg](http://www.openstreetmap.org/#map=17/47.79269/13.00140)):
[apron](http://geo.dianacht.de/bilder/aeroway_apron.png)
