### PR TITLE
distinguish piers as areas from piers as curved lines

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -262,7 +262,7 @@
 	<Layer name="cliffs-lines">
 		<StyleName>cliffs</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,"natural","man_made",highway,barrier FROM planet_osm_line) AS cliff </Parameter>
+			<Parameter name="table">(SELECT way,"natural","man_made",highway,barrier,'no' as area FROM planet_osm_line) AS cliff </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -270,7 +270,7 @@
 	<Layer name="cliffs-polygons">
 		<StyleName>cliffs</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,"natural","man_made",highway,barrier FROM planet_osm_polygon) AS cliff </Parameter>
+			<Parameter name="table">(SELECT way,"natural","man_made",highway,barrier,'yes' as area FROM planet_osm_polygon) AS cliff </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/styles-otm/cliffs.xml
+++ b/mapnik/styles-otm/cliffs.xml
@@ -76,7 +76,13 @@
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom17;
-		<Filter>([man_made] = 'pier')</Filter>
+		<Filter>(([man_made] = 'pier') and ([area] = 'no'))</Filter>
+		<LineSymbolizer stroke="#505050" stroke-width="1"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom13;
+		&minscale_zoom17;
+		<Filter>(([man_made] = 'pier') and ([area] = 'yes'))</Filter>
 		<PolygonSymbolizer fill="white" />
 		<LineSymbolizer stroke="#505050" stroke-width="1"/>
 	</Rule>


### PR DESCRIPTION
piers with corners are interpreted as areas and the "PolygonSymbolizer" in cliffs.xml fills them white (#87).
Now we give "cliffs" one new "tag" area=yes/no to decide wether its a real area (from planet_osm_polygon) or a curved line (from planet_osm_line):

![Pierpatch](https://geo.dianacht.de/bilder/otm_pierpatch.png)

