### PR TITLE
Add crevasses

### DIFF
--- a/mapnik/styles-otm/cliffs.xml
+++ b/mapnik/styles-otm/cliffs.xml
@@ -17,6 +17,28 @@
 		<Filter>([natural] = 'cliff') or ([man_made] = 'embankment')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/cliff_z15.png"/>
 	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([natural] = 'crevasse')</Filter>
+                <LineSymbolizer stroke="#000088" stroke-width="0.5" stroke-opacity="0.05"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([natural] = 'crevasse')</Filter>
+                <LineSymbolizer stroke="#000088" stroke-width="0.5" stroke-opacity="0.1"/>
+	</Rule>
+
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>([natural] = 'crevasse')</Filter>
+                <LineSymbolizer stroke="#000088" stroke-width="0.25" stroke-opacity="0.2"/>
+	</Rule>
 	
 	<Rule>
 		&maxscale_zoom14;


### PR DESCRIPTION
Rendering [natural=crevasse](http://wiki.openstreetmap.org/wiki/Tag:natural%3Dcrevasse) is widely used on topographic maps (e.g. [older bavarian](https://geoportal.bayern.de/bayernatlas/index.html?X=5254541.69&Y=4424109.76&zoom=11&lang=de&topic=zeitr&bgLayer=atkis&layers_timestamp=19861231&time=1986&layers=zeitreihe_tk) or [austrian](http://www.austrianmap.at/amap/index.php?setTo=1%7E201923%7E334296%7E207225%7E331586%7E%40204780%7C333248%7E0%7ELAM_ETRS89%7E1002%7E512) topos). I would not render them very emphasized, because crevasses in maps don't show the place where a crevasse is. It's only a hint where you should expect one (in fact you alway should expect one, but there are palaces where always are a lot of them...)

Example of [this area](https://opentopomap.org/#map=14/46.86811/10.76664):
![Gepatschferner](http://geo.dianacht.de/bilder/otm_crevasses.png)