### PR TITLE
Rotate stations

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -526,7 +526,7 @@
 	<Layer name="symbols-important-point">
 		<StyleName>symbols-important-point</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,name,railway,train,subway,station FROM planet_osm_point) AS names</Parameter>
+			<Parameter name="table">(SELECT way,name,railway,train,subway,station,direction FROM planet_osm_point WHERE (railway='station' OR railway='halt') AND ((direction IS NULL) OR direction SIMILAR TO '[0-9]+')) AS names</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/styles-otm/symbols-important-point.xml
+++ b/mapnik/styles-otm/symbols-important-point.xml
@@ -1,22 +1,78 @@
 <Style name="symbols-important-point">
+
+<!-- Stations without rotation -->
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom13;
 		<!-- bigger stations are normally tagged with train=yes -->
-		<Filter>[railway] = 'station' and [train] = 'yes'</Filter>
-		<PointSymbolizer file="symbols-otm/station_z12.png" allow-overlap="true" />
+		<Filter>[direction]=null and [railway] = 'station' and [train] = 'yes'</Filter>
+		<PointSymbolizer file="symbols-otm/station_square.svg" allow-overlap="true" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
-		<Filter>[railway] = 'station' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
-		<PointSymbolizer file="symbols-otm/station.png" allow-overlap="true" />
+		<Filter>[direction]=null and [railway] = 'station' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_square.svg" allow-overlap="true" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom17;
-		<Filter>[railway] = 'station' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
-		<PointSymbolizer file="symbols-otm/station.png" allow-overlap="true" />
+		<Filter>[direction]=null and [railway] = 'station' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_square.svg" allow-overlap="true" />
 		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="5" wrap-width="100">[name]</TextSymbolizer>
 	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>[direction]=null and [railway] = 'halt' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_square.svg" allow-overlap="true" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom17;
+		<Filter>[direction]=null and [railway] = 'halt' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_square.svg" allow-overlap="true" />
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="5" wrap-width="100">[name]</TextSymbolizer>
+	</Rule>
+
+<!-- Stations with rotation -->
+	<Rule>
+		&maxscale_zoom12;
+		&minscale_zoom13;
+		<!-- bigger stations are normally tagged with train=yes -->
+		<Filter>[direction]!=null and [railway] = 'station' and [train] = 'yes'</Filter>
+		<PointSymbolizer file="symbols-otm/station_rect.svg" allow-overlap="true" transform="rotate([direction]) scale(0.9)"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>[direction]!=null and [railway] = 'station' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_rect.svg" allow-overlap="true"  transform="rotate([direction]) scale(1)"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom17;
+		<Filter>[direction]!=null and [railway] = 'station' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_rect.svg" allow-overlap="true"  transform="rotate([direction]) scale(1)"/>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="7" wrap-width="100">[name]</TextSymbolizer>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>[direction]!=null and [railway] = 'halt' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_rect.svg" allow-overlap="true"  transform="rotate([direction]) scale(0.9)"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom17;
+		<Filter>[direction]!=null and [railway] = 'halt' and not ([subway] = 'yes' or [station] = 'subway')</Filter>
+		<PointSymbolizer file="symbols-otm/station_rect.svg" allow-overlap="true"  transform="rotate([direction]) scale(0.9)"/>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="7" wrap-width="100">[name]</TextSymbolizer>
+	</Rule>
+
+
+
+
 </Style>

--- a/mapnik/symbols-otm/station_rect.svg
+++ b/mapnik/symbols-otm/station_rect.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 744.09448819 1052.3622047"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="station_rect.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="29.847725"
+     inkscape:cx="-127.00572"
+     inkscape:cy="532.90005"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     showguides="false"
+     inkscape:window-width="1152"
+     inkscape:window-height="843"
+     inkscape:window-x="333"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4144"
+       width="8.1262865"
+       height="12.124941"
+       x="-131.06886"
+       y="511.37274" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.97568393;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4142"
+       width="5.1576495"
+       height="9.0440426"
+       x="-129.58455"
+       y="512.91321" />
+  </g>
+</svg>

--- a/mapnik/symbols-otm/station_square.svg
+++ b/mapnik/symbols-otm/station_square.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 744.09448819 1052.3622047"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="station_square.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15"
+     inkscape:cx="-147.3"
+     inkscape:cy="528.13611"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     showguides="false"
+     inkscape:window-width="1676"
+     inkscape:window-height="1004"
+     inkscape:window-x="2"
+     inkscape:window-y="2"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4144"
+       width="8.1262884"
+       height="8.0710325"
+       x="-131.06886"
+       y="515.42664" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.76666665;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4142"
+       width="5.3666668"
+       height="5.3666668"
+       x="-129.68906"
+       y="516.77881" />
+  </g>
+</svg>

--- a/mapnik/tools/stationdirection.sql
+++ b/mapnik/tools/stationdirection.sql
@@ -88,7 +88,6 @@ CREATE OR REPLACE FUNCTION getstationdirection(Point IN GEOMETRY,Stationlayer in
 --
    IF ( d IS NOT NULL ) THEN
     i:=i+1;
---  RAISE NOTICE '% osm_id=%  railway=% layer=% degrees=%',i,result.osm_id,result.railway,result.layer,d;
 --
 --  the first rail is taken, because we don't know if there will come better rails
 --  that's a fall back if we don't get rails with same layer as the station
@@ -100,7 +99,6 @@ CREATE OR REPLACE FUNCTION getstationdirection(Point IN GEOMETRY,Stationlayer in
 -- the first rail with the same layer as the station is taken 
 --
     IF ((foundnextrail=0) AND ((result.layer = Stationlayer) OR ((Stationlayer IS NULL AND result.layer IS NULL) AND (result.tunnel IS NULL)))) THEN
---   RAISE NOTICE '% take that rail',i;
      foundnextrail:=1;
      direction:=d;
     END IF;
@@ -116,12 +114,6 @@ $$ LANGUAGE plpgsql;
 -- Now use this funktion to update the database
 -- --------------------------------------------------------------------------
 
-SELECT now(),count(*) AS stations_to_be_updated  FROM  planet_osm_point 
-       WHERE (railway='station' OR railway='halt') 
-             AND (station IS NULL OR station!='subway') 
-             AND (subway IS NULL OR subway!='yes')
-             AND (direction IS NULL or direction NOT SIMILAR TO '[0-9]+');
-
 UPDATE planet_osm_point 
        SET direction=getstationdirection(way,layer)
        WHERE (railway='station' OR railway='halt') 
@@ -129,11 +121,6 @@ UPDATE planet_osm_point
              AND (subway IS NULL OR subway!='yes')
              AND (direction IS NULL or direction NOT SIMILAR TO '[0-9]+');
 
-SELECT  now(),count(*) AS stations_still_without_direction FROM  planet_osm_point 
-       WHERE (railway='station' OR railway='halt') 
-             AND (station IS NULL OR station!='subway') 
-             AND (subway IS NULL OR subway!='yes')
-             AND (direction IS NULL or direction NOT SIMILAR TO '[0-9]+');
 
 -- ----------------------------------------------------------------
 -- the end

--- a/mapnik/tools/stationdirection.sql
+++ b/mapnik/tools/stationdirection.sql
@@ -1,0 +1,116 @@
+--
+-- FUNCTION INTEGER getstationdirection(Point:GEOMETRY in Mercator,Sztationlayer in TEXT)
+-- --------------------------------------------------------------------------------------
+--
+-- returns the direction of a station at (Point) in degrees (0deg...179deg) (0:north 90:east 180:south)
+--
+-- "Layer" is the layer of the station, but its not used now, because we have a lot of stations at
+--  layer=0 with their rails at layer=-1
+--
+-- Constants
+--    SearchArea:   limit where the next rails must be (in map units, that means "mercator-meter")
+--    SearchLimit:  maximum number of examined railways
+--    RailLength:   lenght of the rails to estimate the tangent to it (in map units)
+--    ErrorReturn:  direction which is returned in case of errors
+--
+--
+-- Algorithm:
+--    get "SearchLimit" rails next to the station (in max. "SearchArea" distance) wich are at least "RailLength" long
+--    cut out a part of (1..2)*"RailLength" of each rail
+--    estimate the tangent of the rails by connecting startpoint of endpoint of this parts
+--    get this rail which ist "most parallel" to the other rails and take its tangent as "direction" of the station
+--    
+--    -> RailLength should be big enough to select the most important rails, but not longer than the usual straight
+--        part along the platforms
+--    -> Searcharea should be small enough to get only rails belonging to this station
+--    -> SearchLimit should be a typical number of rails near a station (maybe 1..10)
+--
+--    
+-- Installation:
+--    psql databasename < path_to_me/stationdirection.sql
+--    (as owner of the database where the stations are, eg "gis")
+--
+--  Test:
+--    SELECT name,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=4436626591;
+--     --> Baiersdorf | 31
+--
+--
+
+CREATE OR REPLACE FUNCTION getstationdirection(point IN GEOMETRY,Stationlayer in TEXT) RETURNS INTEGER AS $$
+
+ DECLARE
+  SearchArea   CONSTANT INTEGER :=  100;
+  SearchLimit  CONSTANT INTEGER :=    5;
+  RailLength   CONSTANT INTEGER :=   30;
+  ErrorReturn  CONSTANT INTEGER :=    0;
+
+  result          RECORD;
+  direction       INTEGER;
+  raildirection   INTEGER [];
+  dirdiff         INTEGER [];
+  i               INTEGER;
+  j               INTEGER;
+  k               INTEGER;
+  d               INTEGER;
+  
+
+
+ BEGIN
+  i:=0;
+  direction:=ErrorReturn;
+--
+-- Loop over some rails next to the station
+--
+  <<railsloop>>  
+  FOR result IN (SELECT osm_id,railway,ST_Intersection(way,ST_Expand(ST_ClosestPoint(way,Point),RailLength)) as railpart
+                        FROM  planet_osm_line AS t1
+                        WHERE ST_DWithin(way,Point,SearchArea)
+                        AND   railway IN ('funicular','light_rail','monorail','narrow_gauge','rail','disused','abandoned','preserved') 
+                        AND   ST_Length(way)>2*RailLength
+--                        AND   (layer=Stationlayer or (Stationlayer is null and layer is null))
+                        ORDER BY st_distance(way,Point) ASC
+                        LIMIT SearchLimit) 
+                        LOOP
+   i:=i+1;d:=0;
+--
+-- get the tangent of the rail
+--
+   SELECT CAST(az AS INTEGER) INTO d FROM (SELECT Degrees(ST_Azimuth(ST_StartPoint(result.railpart),ST_EndPoint(result.railpart)))as az) AS foo;
+   d:=(360+d)%180;
+   raildirection[i]:=d;
+--   RAISE NOTICE '% osm_id=%  railway=% degrees=%',i,result.osm_id,result.railway,raildirection[i];
+   IF (i=1) THEN 
+    direction:=d; 
+   END IF;
+  END LOOP railsloop;
+--
+-- get the "best" rail: mybe we should do some clustering ...
+--
+  IF (i>2) THEN
+   j:=1;
+   WHILE (j<=i) LOOP
+    k:=1;
+    dirdiff[j]:=0;
+    WHILE (k<=i) LOOP
+     dirdiff[j]:=dirdiff[j]+abs(raildirection[j]-raildirection[k])%90;
+--     RAISE NOTICE 'dirdiff %-%: %',j,k,dirdiff[j];
+     k:=k+1;
+    END LOOP;
+    j:=j+1;
+   END LOOP;
+   direction:=raildirection[1];
+   j:=1;k:=1;
+   WHILE (j<=i) LOOP
+    IF (dirdiff[j]<dirdiff[k]) THEN
+     direction:=raildirection[j];
+--     RAISE NOTICE 'dir % won',j;
+     k:=j;
+    END IF;
+    j:=j+1;
+   END LOOP;
+  END IF;
+  RETURN direction;
+ END;
+$$ LANGUAGE plpgsql;
+
+SELECT name,railway,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=4436626591;

--- a/mapnik/tools/stationdirection.sql
+++ b/mapnik/tools/stationdirection.sql
@@ -1,11 +1,8 @@
 --
--- FUNCTION INTEGER getstationdirection(Point:GEOMETRY in Mercator,Sztationlayer in TEXT)
--- --------------------------------------------------------------------------------------
+-- FUNCTION INTEGER getstationdirection(Point:GEOMETRY in Mercator,Stationlayer in TEXT)
+-- -------------------------------------------------------------------------------------
 --
 -- returns the direction of a station at (Point) in degrees (0deg...179deg) (0:north 90:east 180:south)
---
--- "Layer" is the layer of the station, but its not used now, because we have a lot of stations at
---  layer=0 with their rails at layer=-1
 --
 -- Constants
 --    SearchArea:   limit where the next rails must be (in map units, that means "mercator-meter")
@@ -13,18 +10,17 @@
 --    RailLength:   lenght of the rails to estimate the tangent to it (in map units)
 --    ErrorReturn:  direction which is returned in case of errors
 --
---
--- Algorithm:
---    get "SearchLimit" rails next to the station (in max. "SearchArea" distance) wich are at least "RailLength" long
---    cut out a part of (1..2)*"RailLength" of each rail
---    estimate the tangent of the rails by connecting startpoint of endpoint of this parts
---    get this rail which ist "most parallel" to the other rails and take its tangent as "direction" of the station
---    
 --    -> RailLength should be big enough to select the most important rails, but not longer than the usual straight
 --        part along the platforms
 --    -> Searcharea should be small enough to get only rails belonging to this station
 --    -> SearchLimit should be a typical number of rails near a station (maybe 1..10)
 --
+-- Algorithm:
+--    get "SearchLimit" rails next to the station (in max. "SearchArea" distance) wich are at least "RailLength" long
+--    cut out a part of (1..2)*"RailLength" of each rail
+--    estimate the direction of the tangent of the rails by connecting startpoint of endpoint of this parts
+--    get the direction from the station to this rail
+--    estimate from this 2 directions wether it's a terminal or not
 --    
 -- Installation:
 --    psql databasename < path_to_me/stationdirection.sql
@@ -40,19 +36,17 @@ CREATE OR REPLACE FUNCTION getstationdirection(point IN GEOMETRY,Stationlayer in
 
  DECLARE
   SearchArea   CONSTANT INTEGER :=  100;
-  SearchLimit  CONSTANT INTEGER :=    5;
+  SearchLimit  CONSTANT INTEGER :=    8;
   RailLength   CONSTANT INTEGER :=   30;
   ErrorReturn  CONSTANT INTEGER :=    0;
 
   result          RECORD;
   direction       INTEGER;
-  raildirection   INTEGER [];
-  dirdiff         INTEGER [];
+  foundnextrail   INTEGER;
+  is_a_terminal   INTEGER;
   i               INTEGER;
-  j               INTEGER;
-  k               INTEGER;
   d               INTEGER;
-  
+  cl              INTEGER;
 
 
  BEGIN
@@ -61,56 +55,69 @@ CREATE OR REPLACE FUNCTION getstationdirection(point IN GEOMETRY,Stationlayer in
 --
 -- Loop over some rails next to the station
 --
+  foundnextrail:=0;
+  is_a_terminal:=0;
   <<railsloop>>  
-  FOR result IN (SELECT osm_id,railway,ST_Intersection(way,ST_Expand(ST_ClosestPoint(way,Point),RailLength)) as railpart
+  FOR result IN (SELECT osm_id,railway,layer,tunnel,
+                        ST_Intersection(way,ST_Expand(ST_ClosestPoint(way,Point),RailLength)) as railpart,
+                        ST_ClosestPoint(way,Point) as closestpoint
                         FROM  planet_osm_line AS t1
                         WHERE ST_DWithin(way,Point,SearchArea)
-                        AND   railway IN ('funicular','light_rail','monorail','narrow_gauge','rail','disused','abandoned','preserved') 
+                        AND   railway IN ('funicular','light_rail','monorail','narrow_gauge','rail','disused','abandoned','preserved','subway') 
                         AND   ST_Length(way)>2*RailLength
---                        AND   (layer=Stationlayer or (Stationlayer is null and layer is null))
                         ORDER BY st_distance(way,Point) ASC
                         LIMIT SearchLimit) 
                         LOOP
-   i:=i+1;d:=0;
 --
--- get the tangent of the rail
+-- get the direction d of "tangent" of the rail and the direction cl of the line from the station to this rail
 --
-   SELECT CAST(az AS INTEGER) INTO d FROM (SELECT Degrees(ST_Azimuth(ST_StartPoint(result.railpart),ST_EndPoint(result.railpart)))as az) AS foo;
+   SELECT CAST(az AS INTEGER) INTO d  FROM (SELECT Degrees(ST_Azimuth(ST_StartPoint(result.railpart),ST_EndPoint(result.railpart)))as az) AS foo;
+   SELECT CAST(az AS INTEGER) INTO cl FROM (SELECT Degrees(ST_Azimuth(Point,result.closestpoint))as az) AS foo;
    d:=(360+d)%180;
-   raildirection[i]:=d;
---   RAISE NOTICE '% osm_id=%  railway=% degrees=%',i,result.osm_id,result.railway,raildirection[i];
-   IF (i=1) THEN 
-    direction:=d; 
+   cl=(360+cl)%180;
+--
+-- d is null, if the rail is a loop (way 32517428)
+--
+   IF ( d IS NOT NULL ) THEN
+   i:=i+1;
+--
+-- a station is a terminal of a rail, if the angle between d and cl is not about 90 degrees 
+-- if (cl=NULL) the station is part of the rail and it is not a terminal
+--
+    is_a_terminal:=0;
+--    IF ((cl IS NOT NULL) AND ((abs(d-cl)<45) OR (abs(d-cl)>135))) THEN is_a_terminal:=1; END IF;
+    RAISE NOTICE '% osm_id=%  railway=% layer=% degrees=% shortestline=% terminal=%',i,result.osm_id,result.railway,result.layer,d,cl,is_a_terminal;
+--
+-- the first rail is taken, because we don't know if there will come better rails
+-- that's a fall back if we don't get rails with same layer as the station
+--
+    IF (i=1) THEN
+     direction:=d;
+     IF (is_a_terminal = 1) THEN direction=(direction+90)%180; END IF;
+    END IF;
+--
+-- the first rail with the same layer as the station is taken 
+-- if the station is a terminal it is rotated by 90 degrees
+--
+    IF ((foundnextrail=0) AND ((result.layer = Stationlayer) OR ((Stationlayer IS NULL AND result.layer IS NULL) AND (result.tunnel IS NULL)))) THEN
+     RAISE NOTICE '% take that rail',i;
+     foundnextrail:=1;
+     direction:=d;
+     IF (is_a_terminal = 1) THEN direction=(direction+90)%180; END IF;
+    END IF;
    END IF;
   END LOOP railsloop;
---
--- get the "best" rail: mybe we should do some clustering ...
---
-  IF (i>2) THEN
-   j:=1;
-   WHILE (j<=i) LOOP
-    k:=1;
-    dirdiff[j]:=0;
-    WHILE (k<=i) LOOP
-     dirdiff[j]:=dirdiff[j]+abs(raildirection[j]-raildirection[k])%90;
---     RAISE NOTICE 'dirdiff %-%: %',j,k,dirdiff[j];
-     k:=k+1;
-    END LOOP;
-    j:=j+1;
-   END LOOP;
-   direction:=raildirection[1];
-   j:=1;k:=1;
-   WHILE (j<=i) LOOP
-    IF (dirdiff[j]<dirdiff[k]) THEN
-     direction:=raildirection[j];
---     RAISE NOTICE 'dir % won',j;
-     k:=j;
-    END IF;
-    j:=j+1;
-   END LOOP;
-  END IF;
   RETURN direction;
  END;
 $$ LANGUAGE plpgsql;
 
-SELECT name,railway,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=4436626591;
+-- Tests
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=4436626591;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=58822410;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=2499357757;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=286674799;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=3090733718;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=327613695;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=3419908160;
+-- SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=317954672;
+ SELECT name,railway,layer,getstationdirection(way,layer) as direction from planet_osm_point where osm_id=2473297785;


### PR DESCRIPTION
Patch for Issue #74 

After merging and after each database import you have to estimate the direction of the stations once:
`psql gis <  /path/to/stationdirection.sql`
The programm updates stations with direction=(null or text) and sets direction to null if it can't calculate it. So you can repeat it after a database update. Forgetting to call stationdirection.sql is not harmfull, stations will be rendered like now.

Mapped directions are overwritten, but loosing [10 directions](http://overpass-turbo.eu/s/oxt) like "eastward" is ok.
