### PR TITLE
render attraction=summer_toboggan and (leisure=track and sport=bobsleigh)

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -255,7 +255,8 @@
 		<StyleName>tunnels-fill</StyleName>
 		<StyleName>tunnels-middle</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,tracktype,oneway,attraction,sport,leisure,surface FROM planet_osm_line WHERE (tunnel = 'yes') AND (highway IS NOT NULL OR attraction='summer_toboggan' OR leisure='track')) AS roads </Parameter>
+<!-- attraction         <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,tracktype,oneway,attraction,sport,leisure,surface FROM planet_osm_line WHERE (tunnel = 'yes') AND (highway IS NOT NULL OR attraction='summer_toboggan' OR leisure='track')) AS roads </Parameter> -->
+                        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,tracktype,oneway,NULL AS attraction,sport,leisure,surface FROM planet_osm_line WHERE (tunnel = 'yes') AND (highway IS NOT NULL OR leisure='track')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -394,7 +395,8 @@
 		<StyleName>roads-fill</StyleName>
 		<StyleName>trams</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway,leisure,sport,attraction FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
+<!-- attraction         <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway,leisure,sport,attraction FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram' OR leisure='track' OR attraction='summer_toboggan') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter> -->
+                        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway,leisure,sport,NULL AS attraction FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram' OR leisure='track') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -444,7 +446,8 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter>
+<!-- attraction	        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter> -->
+                        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,NULL AS attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -457,7 +460,8 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer = '2')) AS roads </Parameter>
+<!-- attraction         <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer = '2')) AS roads </Parameter> -->
+                        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,NULL AS attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer = '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -470,7 +474,8 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer &gt; '2')) AS roads </Parameter>
+<!-- attraction         <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer &gt; '2')) AS roads </Parameter> -->
+                        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,NULL AS attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer &gt; '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -584,7 +589,8 @@
 	<Layer name="road-names-text">
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,service,surface,tracktype,lanes,embankment,oneway FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR (leisure='track' AND sport='bobsleigh') OR attraction='summer_toboggan') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
+<!-- attraction         <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,service,surface,tracktype,lanes,embankment,oneway FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR (leisure='track' AND sport='bobsleigh') OR attraction='summer_toboggan') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter> -->
+                        <Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,service,surface,tracktype,lanes,embankment,oneway FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR (leisure='track' AND sport='bobsleigh')) ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -394,7 +394,7 @@
 		<StyleName>roads-fill</StyleName>
 		<StyleName>trams</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway,leisure,sport FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram' OR leisure='track') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway,leisure,sport,attraction FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -444,7 +444,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -457,7 +457,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer = '2')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') AND (layer = '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -470,7 +470,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer &gt; '2')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') AND (layer &gt; '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -394,7 +394,7 @@
 		<StyleName>roads-fill</StyleName>
 		<StyleName>trams</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,sac_scale,trail_visibility,via_ferrata_scale,service,surface,tracktype,lanes,embankment,oneway,railway,leisure,sport FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR railway='tram' OR leisure='track') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -444,7 +444,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer IS NULL OR layer &lt;= '1')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -457,7 +457,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram') AND (layer = '2')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer = '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -470,7 +470,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram') AND (layer &gt; '2')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track') AND (layer &gt; '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -255,7 +255,7 @@
 		<StyleName>tunnels-fill</StyleName>
 		<StyleName>tunnels-middle</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,tracktype,oneway FROM planet_osm_line WHERE (tunnel = 'yes') AND highway IS NOT NULL) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,tracktype,oneway,attraction,sport,leisure,surface FROM planet_osm_line WHERE (tunnel = 'yes') AND (highway IS NOT NULL OR attraction='summer_toboggan' OR leisure='track')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -457,7 +457,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') AND (layer = '2')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer = '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -470,7 +470,7 @@
 		<StyleName>trams</StyleName>
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan' OR attraction='roller_coaster') AND (layer &gt; '2')) AS roads </Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,service,surface,tracktype,layer,name,railway,oneway,leisure,sport,attraction FROM planet_osm_line WHERE (bridge != 'no') AND (highway IS NOT NULL OR railway = 'tram' OR leisure='track' OR attraction='summer_toboggan') AND (layer &gt; '2')) AS roads </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>
@@ -584,7 +584,7 @@
 	<Layer name="road-names-text">
 		<StyleName>road-names-text</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,service,surface,tracktype,lanes,embankment,oneway FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND highway IS NOT NULL ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
+			<Parameter name="table">(SELECT way,ST_Length(way) AS length,highway,name,service,surface,tracktype,lanes,embankment,oneway FROM planet_osm_line WHERE (!scale_denominator! &gt; 300000) OR ((bridge IS NULL OR bridge = 'no') AND (tunnel IS NULL OR tunnel != 'yes')) AND (highway IS NOT NULL OR (leisure='track' AND sport='bobsleigh') OR attraction='summer_toboggan') ORDER BY (CASE WHEN highway IN ('motorway','trunk') THEN 5 WHEN highway='primary' THEN 1 WHEN highway='secondary' THEN 2 WHEN highway='tertiary' THEN 3 ELSE 4 END) DESC ) AS roads</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/osm2pgsql/opentopomap.style
+++ b/mapnik/osm2pgsql/opentopomap.style
@@ -84,6 +84,7 @@ node,way   aerialway    text         linear
 node,way   aeroway      text         polygon
 node,way   amenity      text         polygon
 node,way   area         text         # hard coded support for area=1/yes => polygon is in osm2pgsql
+node,way   attraction   text         linear
 node,way   barrier      text         linear
 node,way   bicycle      text
 node,way   brand        text         linear

--- a/mapnik/styles-otm/bridges-casing.xml
+++ b/mapnik/styles-otm/bridges-casing.xml
@@ -730,7 +730,7 @@
 		<LineSymbolizer stroke="black" stroke-width="3" stroke-dasharray="1.1,2"/>
 	</Rule>
 
-<!-- bobsleight -->
+<!-- bobsleight and summer toboggan -->
 
 	<Rule>
 		&maxscale_zoom14;
@@ -787,5 +787,62 @@
 		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
 		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
 	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="black" stroke-width="1.5" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([length] &gt; 3 and [attraction]='summer_toboggan')</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="black" stroke-width="2" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([length] &gt; 3 and [attraction]='summer_toboggan')</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="black" stroke-width="3" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([length] &gt; 3 and [attraction]='summer_toboggan')</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+	
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="black" stroke-width="3.5" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([length] &gt; 3 and [attraction]='summer_toboggan')</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+
 
 </Style>

--- a/mapnik/styles-otm/bridges-casing.xml
+++ b/mapnik/styles-otm/bridges-casing.xml
@@ -730,4 +730,62 @@
 		<LineSymbolizer stroke="black" stroke-width="3" stroke-dasharray="1.1,2"/>
 	</Rule>
 
+<!-- bobsleight -->
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="black" stroke-width="1.5" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([length] &gt; 3 and [leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="black" stroke-width="2" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([length] &gt; 3 and [leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="black" stroke-width="3" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([length] &gt; 3 and [leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+	
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="black" stroke-width="3.5" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([length] &gt; 3 and [leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_first.png" placement="vertex-first" allow-overlap="true" ignore-placement="true" />
+		<MarkersSymbolizer file="symbols-otm/bridge_1px_last.png" placement="vertex-last" allow-overlap="true" ignore-placement="true" />
+	</Rule>
+
 </Style>

--- a/mapnik/styles-otm/bridges-fill.xml
+++ b/mapnik/styles-otm/bridges-fill.xml
@@ -472,27 +472,27 @@
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>([attraction]='summer_toboggan')</Filter>
-		<LineSymbolizer stroke="#DDEEFF" stroke-width="1" stroke-linecap="round"/>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="1" stroke-linecap="round"/>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>([attraction]='summer_toboggan')</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="1.5" stroke-linecap="round"/>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="1.5" stroke-linecap="round"/>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>([attraction]='summer_toboggan')</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="2" stroke-linecap="round"/>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="2" stroke-linecap="round"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<Filter>([attraction]='summer_toboggan')</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="2.5" stroke-linecap="round"/>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="2.5" stroke-linecap="round"/>
 	</Rule>
 
 

--- a/mapnik/styles-otm/bridges-fill.xml
+++ b/mapnik/styles-otm/bridges-fill.xml
@@ -439,7 +439,7 @@
 		<LinePatternSymbolizer file="symbols-otm/oneway_long.png" />
 	</Rule>
 
-<!-- bobsleigh -->
+<!-- bobsleigh and summer toboggan-->
 
 	<Rule>
 		&maxscale_zoom14;
@@ -467,6 +467,34 @@
 		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
 		<LineSymbolizer stroke="#DDEEFF" stroke-width="2.5" stroke-linecap="round"/>
 	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1" stroke-linecap="round"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="1.5" stroke-linecap="round"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="2" stroke-linecap="round"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([attraction]='summer_toboggan')</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="2.5" stroke-linecap="round"/>
+	</Rule>
+
 
 
 </Style>

--- a/mapnik/styles-otm/bridges-fill.xml
+++ b/mapnik/styles-otm/bridges-fill.xml
@@ -439,4 +439,35 @@
 		<LinePatternSymbolizer file="symbols-otm/oneway_long.png" />
 	</Rule>
 
+<!-- bobsleigh -->
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1" stroke-linecap="round"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1.5" stroke-linecap="round"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="2" stroke-linecap="round"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="2.5" stroke-linecap="round"/>
+	</Rule>
+
+
 </Style>
+

--- a/mapnik/styles-otm/roads-casing.xml
+++ b/mapnik/styles-otm/roads-casing.xml
@@ -666,5 +666,35 @@
 		<Filter>([highway] = 'primary' or [highway] = 'secondary') and ([embankment] = 'yes')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/embankment_12px.png"/>
 	</Rule>
+	
+<!-- bobsleigh -->
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#333377" stroke-width="1.5" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#333377" stroke-width="2" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#333377" stroke-width="3" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#333377" stroke-width="3.5" />
+	</Rule>
+
 
 </Style>

--- a/mapnik/styles-otm/roads-casing.xml
+++ b/mapnik/styles-otm/roads-casing.xml
@@ -667,7 +667,7 @@
 		<LinePatternSymbolizer file="symbols-otm/embankment_12px.png"/>
 	</Rule>
 	
-<!-- bobsleigh -->
+<!-- bobsleigh and summer toboggan-->
 
 	<Rule>
 		&maxscale_zoom14;
@@ -694,6 +694,33 @@
 		&minscale_zoom17;
 		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
 		<LineSymbolizer stroke="#333377" stroke-width="3.5" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#333333" stroke-width="1.5" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#333333" stroke-width="2" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#333333" stroke-width="3" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#333333" stroke-width="3.5" />
 	</Rule>
 
 

--- a/mapnik/styles-otm/roads-casing.xml
+++ b/mapnik/styles-otm/roads-casing.xml
@@ -700,27 +700,27 @@
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#333333" stroke-width="1.5" />
+		<LineSymbolizer stroke="#333333" stroke-width="1.3" />
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#333333" stroke-width="2" />
+		<LineSymbolizer stroke="#333333" stroke-width="1.8" />
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#333333" stroke-width="3" />
+		<LineSymbolizer stroke="#333333" stroke-width="2.7" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#333333" stroke-width="3.5" />
+		<LineSymbolizer stroke="#333333" stroke-width="3.2" />
 	</Rule>
 
 

--- a/mapnik/styles-otm/roads-fill.xml
+++ b/mapnik/styles-otm/roads-fill.xml
@@ -475,5 +475,34 @@
 		<LinePatternSymbolizer file="symbols-otm/lanes_5.png" />
 	</Rule>-->
 
+<!-- bobsleigh -->
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1.2" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1.8" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="2.5" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="3.0" />
+	</Rule>
+
 
 </Style>

--- a/mapnik/styles-otm/roads-fill.xml
+++ b/mapnik/styles-otm/roads-fill.xml
@@ -475,7 +475,7 @@
 		<LinePatternSymbolizer file="symbols-otm/lanes_5.png" />
 	</Rule>-->
 
-<!-- bobsleigh -->
+<!-- bobsleigh ans summer toboggan-->
 
 	<Rule>
 		&maxscale_zoom14;
@@ -503,6 +503,35 @@
 		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
 		<LineSymbolizer stroke="#DDEEFF" stroke-width="3.0" />
 	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="1.2" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="1.8" />
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="2.5" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#eeeeee" stroke-width="3.0" />
+	</Rule>
+
+
 
 
 </Style>

--- a/mapnik/styles-otm/roads-fill.xml
+++ b/mapnik/styles-otm/roads-fill.xml
@@ -508,30 +508,27 @@
 		&maxscale_zoom14;
 		&minscale_zoom14;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="1.2" />
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="1.0" />
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="1.8" />
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="1.5" />
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="2.5" />
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="2.3" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
 		<Filter>[attraction]='summer_toboggan'</Filter>
-		<LineSymbolizer stroke="#eeeeee" stroke-width="3.0" />
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="2.8" />
 	</Rule>
-
-
-
 
 </Style>

--- a/mapnik/styles-otm/tunnels-fill.xml
+++ b/mapnik/styles-otm/tunnels-fill.xml
@@ -400,5 +400,62 @@
 		<Filter>[oneway] = 'yes' and [length] &gt; 200</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway_long.png" />
 	</Rule>
+
+<!-- bobsleigh ans summer toboggan-->
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1.2" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="1.8" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="2.5" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([leisure] = 'track' and ( [sport] = 'bobsleigh' or [surface] = 'ice' or [surface] = 'snow' ))</Filter>
+		<LineSymbolizer stroke="#DDEEFF" stroke-width="3.0" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom14;
+		&minscale_zoom14;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="1.0" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom15;
+		&minscale_zoom15;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="1.5" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom17;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="2.3" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>[attraction]='summer_toboggan'</Filter>
+		<LineSymbolizer stroke="#e0e0e0" stroke-width="2.8" stroke-linecap="round" stroke-opacity="0.5"/>
+	</Rule>
+
 	
 </Style>


### PR DESCRIPTION
PR for #106 

Toboggans are now smaller and darker to be shown differently as streets. They get labels at zoom level >=16.
We will get the column attraction at the next update. Until this all queries with attraction are commented out in mapnik/opentopomap.xml.

![Summer Toboggan V2](http://geo.dianacht.de/bilder/otm_toboggan_2_14-16.png)
([Timoks Coaster](http://www.openstreetmap.org/way/178572564#map=17/47.45765/12.53757), [Sommerrodelbahn FisserFlitzer](http://www.openstreetmap.org/way/82297799#map=18/47.05737/10.61067) and [Eisarena Königsee](http://www.openstreetmap.org/way/130658309#map=17/47.58774/12.98352))