### PR TITLE
implement soccer fields

### DIFF
--- a/mapnik/HOWTO_Preprocessing
+++ b/mapnik/HOWTO_Preprocessing
@@ -24,6 +24,8 @@ HOWTO preprocess a newly imported database
 	update_saddles.sh 
 	psql gis < stationdirection.sql 
 	psql gis < viewpointdirection.sql
+        psql gis < pitchicon.sql
+
 		
 
 
@@ -32,9 +34,6 @@ HOWTO preprocess a newly imported database
 
 
 	
-
-
-
 
 
 

--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -71,6 +71,7 @@
 	<!ENTITY symbols-1 SYSTEM "styles-otm/symbols-1.xml">
 	<!ENTITY symbols-2 SYSTEM "styles-otm/symbols-2.xml">
 	<!ENTITY symbols-poly SYSTEM "styles-otm/symbols-poly.xml">
+        <!ENTITY symbols-sport SYSTEM "styles-otm/symbols-sport.xml">
 	<!ENTITY symbols-point SYSTEM "styles-otm/symbols-point.xml">
         <!ENTITY symbols-viewpoint SYSTEM "styles-otm/symbols-viewpoint.xml">
         <!ENTITY symbols-saddle SYSTEM "styles-otm/symbols-saddle.xml">
@@ -152,6 +153,7 @@
 	&symbols-1;
 	&symbols-2;
 	&symbols-poly;
+        &symbols-sport;
 	&symbols-point;
         &symbols-viewpoint;
 	&text-roads-ref;
@@ -562,6 +564,17 @@
 			&postgis-settings;
 		</Datasource>
 	</Layer>
+
+	<Layer name="symbols-sport">
+		<StyleName>symbols-sport</StyleName>
+		<Datasource>
+			<Parameter name="table">(SELECT way,(pitchdata).icon AS icon,(pitchdata).angle AS angle,(pitchdata).pitch_area AS pitch_area,(pitchdata).labelsizefactor AS labelsizefactor FROM (select way,getpitchicon(way,sport) as pitchdata FROM planet_osm_polygon WHERE leisure='pitch' AND (building IS NULL OR building = 'no')) AS pitches) AS symbols </Parameter>
+			<Parameter name="dbname">gis</Parameter>
+			&postgis-settings;
+		</Datasource>
+	</Layer>
+
+
 
 	<Layer name="symbols-saddle">
 		<StyleName>symbols-saddle</StyleName>

--- a/mapnik/styles-otm/symbols-sport.xml
+++ b/mapnik/styles-otm/symbols-sport.xml
@@ -1,0 +1,99 @@
+<Style name="symbols-sport">
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='soccer' and [pitch_area] &lt; 3500)</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.0776*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='soccer' and [pitch_area] &lt; 3500)</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.15525*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='soccer' and [pitch_area] &gt;= 3500 and [pitch_area] &lt; 10000)</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.1035*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='soccer' and [pitch_area] &gt;= 3500 and [pitch_area] &lt; 10000)</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.207*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='soccer' and [pitch_area] &gt;= 10000)</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.12075*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='soccer' and [pitch_area] &gt;= 10000)</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.2415*[labelsizefactor])"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='tennis')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-tennis.svg" transform="rotate([angle]) scale(0.0517*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='tennis')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-tennis.svg" transform="rotate([angle]) scale(0.1035*[labelsizefactor])"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='basketball')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-basketball.svg" transform="rotate([angle]) scale(0.0517*[labelsizefactor])"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='rugby')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-rugby.svg" transform="rotate([angle]) scale(0.1725*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='rugby')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-rugby.svg" transform="rotate([angle]) scale(0.345*[labelsizefactor])"/>
+	</Rule>
+
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='football')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-foot-us.svg" transform="rotate([angle]) scale(0.1035*[labelsizefactor])"/>
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='football')</Filter>
+                <PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-foot-us.svg" transform="rotate([angle]) scale(0.207*[labelsizefactor])"/>
+	</Rule>
+
+</Style>
+

--- a/mapnik/symbols-otm/sports-basketball.svg
+++ b/mapnik/symbols-otm/sports-basketball.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="800px" height="600px" viewBox="0 0 800 600" enable-background="new 0 0 800 600" xml:space="preserve">
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="43.31" y1="114.045" x2="323.31" y2="114.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="43.31" y1="114.045" x2="43.31" y2="264.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="43.31" y1="264.045" x2="323.31" y2="264.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="183.31" y1="114.045" x2="183.31" y2="264.045"/>
+<circle fill="none" stroke="#FFFFFF" stroke-width="2" cx="183.31" cy="189.045" r="18"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="59.06" y1="121.545" x2="76.53" y2="123.845"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="76.53" y1="123.845" x2="92.81" y2="130.588"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="92.81" y1="130.588" x2="106.789" y2="141.315"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="106.789" y1="141.315" x2="117.516" y2="155.295"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="117.516" y1="155.295" x2="124.26" y2="171.575"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="124.26" y1="171.575" x2="126.56" y2="189.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="126.56" y1="189.045" x2="124.26" y2="206.515"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="124.26" y1="206.515" x2="117.516" y2="222.795"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="117.516" y1="222.795" x2="106.789" y2="236.774"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="106.789" y1="236.774" x2="92.81" y2="247.501"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="92.81" y1="247.501" x2="76.53" y2="254.245"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="76.53" y1="254.245" x2="59.06" y2="256.545"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="59.06" y1="256.545" x2="43.31" y2="256.545"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="59.06" y1="121.545" x2="43.31" y2="121.545"/>
+<circle fill="none" stroke="#FFFFFF" stroke-width="2" cx="59.06" cy="189.045" r="5"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="48.31" y1="180.31" x2="48.31" y2="197.78"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="54.06" y1="189.045" x2="48.31" y2="189.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="323.31" y1="264.045" x2="323.31" y2="114.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="307.56" y1="256.545" x2="290.089" y2="254.245"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="290.089" y1="254.245" x2="273.81" y2="247.502"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="273.81" y1="247.502" x2="259.83" y2="236.774"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="259.83" y1="236.774" x2="249.103" y2="222.795"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="249.103" y1="222.795" x2="242.359" y2="206.515"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="242.359" y1="206.515" x2="240.06" y2="189.045"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="240.06" y1="189.045" x2="242.359" y2="171.575"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="242.359" y1="171.575" x2="249.103" y2="155.295"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="249.103" y1="155.295" x2="259.83" y2="141.315"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="259.83" y1="141.315" x2="273.81" y2="130.588"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="273.81" y1="130.588" x2="290.089" y2="123.845"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="290.089" y1="123.845" x2="307.56" y2="121.545"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="307.56" y1="121.545" x2="323.31" y2="121.545"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="307.56" y1="256.545" x2="323.31" y2="256.545"/>
+<circle fill="none" stroke="#FFFFFF" stroke-width="2" cx="307.56" cy="189.045" r="5"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="318.31" y1="197.78" x2="318.31" y2="180.31"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" x1="312.56" y1="189.045" x2="318.31" y2="189.045"/>
+</svg>

--- a/mapnik/symbols-otm/sports-foot-us.svg
+++ b/mapnik/symbols-otm/sports-foot-us.svg
@@ -1,0 +1,958 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg2" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" sodipodi:docname="acre over football field.svg" inkscape:version="0.45" inkscape:output_extension="org.inkscape.output.svg.inkscape" xmlns:cc="http://web.resource.org/cc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" sodipodi:modified="true" sodipodi:version="0.32" sodipodi:docbase="W:\"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="323.149px"
+	 height="155.906px" viewBox="0 0 323.149 155.906" enable-background="new 0 0 323.149 155.906" xml:space="preserve">
+<sodipodi:namedview  id="base" inkscape:pageshadow="2" inkscape:zoom="1" inkscape:window-x="12" borderopacity="1.0" inkscape:window-y="45" inkscape:cx="285.78128" inkscape:window-height="913" inkscape:window-width="1226" bordercolor="#666666" inkscape:cy="175.35495" showgrid="true" inkscape:pageopacity="0.83921569" pagecolor="#61c369" inkscape:current-layer="layer1" inkscape:document-units="mm" showborder="true" gridtolerance="0.125mm" guidetolerance="0.125mm" gridspacingx="5mm" gridoriginy="0mm" gridoriginx="0mm" gridspacingy="5mm">
+	</sodipodi:namedview>
+<g id="layer4" inkscape:label="acre" inkscape:groupmode="layer">
+</g>
+<g id="layer1" inkscape:label="field" inkscape:groupmode="layer">
+	<g id="g6025" transform="translate(10.62978,10.62993)">
+		
+			<rect id="rect1307" x="-28.69" y="157.269" fill="none" stroke="#FFFFFF" stroke-width="1.7717" stroke-linecap="round" stroke-linejoin="round" width="382.681" height="173.622"/>
+		
+			<rect id="rect2182" x="-28.688" y="157.269" fill="none" stroke="#FFFFFF" stroke-width="1.7717" stroke-linecap="round" stroke-linejoin="round" width="31.89" height="173.622"/>
+		
+			<rect id="rect2184" x="322.454" y="157.269" fill="none" stroke="#FFFFFF" stroke-width="1.7717" stroke-linecap="round" stroke-linejoin="round" width="31.889" height="173.622"/>
+		<path id="path2186" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M19.647,157.173v173.813"/>
+		<path id="path2188" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M22.671,159.266v5.131"/>
+		<path id="path2190" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M25.855,159.266v5.131"/>
+		<path id="path2192" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M29.039,159.266v5.131"/>
+		<path id="path2194" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M32.223,159.266v5.131"/>
+		<path id="path2212" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M22.671,323.764v5.131"/>
+		<path id="path2214" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M25.855,323.764v5.131"/>
+		<path id="path2216" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M29.039,323.764v5.131"/>
+		<path id="path2218" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M32.223,323.764v5.131"/>
+		<path id="path2241" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M6.402,159.266v5.131"/>
+		<path id="path2245" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M9.587,159.266v5.131"/>
+		<path id="path2247" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M12.771,159.266v5.131"/>
+		<path id="path2249" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M15.955,159.266v5.131"/>
+		<path id="path2267" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M6.402,323.764v5.131"/>
+		<path id="path2269" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M9.587,323.764v5.131"/>
+		<path id="path2271" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M12.771,323.764v5.131"/>
+		<path id="path2273" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M15.955,323.764v5.131"/>
+		<path id="path2279" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M51.537,157.173v173.813"/>
+		<path id="path2277" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M54.561,159.266v5.131"/>
+		<path id="path2281" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M57.745,159.266v5.131"/>
+		<path id="path2283" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M60.929,159.266v5.131"/>
+		<path id="path2285" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M64.113,159.266v5.131"/>
+		<path id="path2303" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M54.561,323.764v5.131"/>
+		<path id="path2305" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M57.745,323.764v5.131"/>
+		<path id="path2307" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M60.929,323.764v5.131"/>
+		<path id="path2309" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M64.113,323.764v5.131"/>
+		<path id="path2315" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M35.268,157.173v173.813"/>
+		<path id="path2313" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M38.292,159.266v5.131"/>
+		<path id="path2317" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M41.476,159.266v5.131"/>
+		<path id="path2319" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M44.66,159.266v5.131"/>
+		<path id="path2321" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M47.844,159.266v5.131"/>
+		<path id="path2339" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M38.292,323.764v5.131"/>
+		<path id="path2341" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M41.476,323.764v5.131"/>
+		<path id="path2343" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M44.66,323.764v5.131"/>
+		<path id="path2345" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M47.844,323.764v5.131"/>
+		<path id="path2351" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M83.426,157.173v173.813"/>
+		<path id="path2349" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M86.45,159.266v5.131"/>
+		<path id="path2353" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M89.634,159.266v5.131"/>
+		<path id="path2355" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M92.818,159.266v5.131"/>
+		<path id="path2357" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M96.003,159.266v5.131"/>
+		<path id="path2375" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M86.45,323.764v5.131"/>
+		<path id="path2377" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M89.634,323.764v5.131"/>
+		<path id="path2379" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M92.818,323.764v5.131"/>
+		<path id="path2381" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M96.003,323.764v5.131"/>
+		<path id="path2387" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M67.158,157.173v173.813"/>
+		<path id="path2385" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M70.182,159.266v5.131"/>
+		<path id="path2389" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M73.366,159.266v5.131"/>
+		<path id="path2391" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M76.55,159.266v5.131"/>
+		<path id="path2393" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M79.734,159.266v5.131"/>
+		<path id="path2411" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M70.182,323.764v5.131"/>
+		<path id="path2413" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M73.366,323.764v5.131"/>
+		<path id="path2415" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M76.55,323.764v5.131"/>
+		<path id="path2417" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M79.734,323.764v5.131"/>
+		<path id="path2423" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M115.317,157.173v173.813"/>
+		<path id="path2421" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M118.34,159.266v5.131"/>
+		<path id="path2425" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M121.525,159.266v5.131"/>
+		<path id="path2427" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M124.709,159.266v5.131"/>
+		<path id="path2429" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M127.893,159.266v5.131"/>
+		<path id="path2447" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M118.34,323.764v5.131"/>
+		<path id="path2449" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M121.525,323.764v5.131"/>
+		<path id="path2451" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M124.709,323.764v5.131"/>
+		<path id="path2453" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M127.893,323.764v5.131"/>
+		<path id="path2459" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M99.048,157.173v173.813"/>
+		<path id="path2457" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M102.071,159.266v5.131"/>
+		<path id="path2461" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M105.256,159.266v5.131"/>
+		<path id="path2463" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M108.44,159.266v5.131"/>
+		<path id="path2465" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M111.624,159.266v5.131"/>
+		<path id="path2483" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M102.071,323.764v5.131"/>
+		<path id="path2485" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M105.255,323.764v5.131"/>
+		<path id="path2487" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M108.44,323.764v5.131"/>
+		<path id="path2489" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M111.624,323.764v5.131"/>
+		<path id="path2495" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M147.206,157.173v173.813"/>
+		<path id="path2493" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M150.23,159.266v5.131"/>
+		<path id="path2497" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M153.415,159.266v5.131"/>
+		<path id="path2499" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M156.598,159.266v5.131"/>
+		<path id="path2501" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M159.782,159.266v5.131"/>
+		<path id="path2519" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M150.23,323.764v5.131"/>
+		<path id="path2521" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M153.415,323.764v5.131"/>
+		<path id="path2523" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M156.598,323.764v5.131"/>
+		<path id="path2525" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M159.782,323.764v5.131"/>
+		<path id="path2531" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M130.938,157.173v173.813"/>
+		<path id="path2529" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M133.962,159.266v5.131"/>
+		<path id="path2533" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M137.145,159.266v5.131"/>
+		<path id="path2535" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M140.33,159.266v5.131"/>
+		<path id="path2537" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M143.514,159.266v5.131"/>
+		<path id="path2555" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M133.962,323.764v5.131"/>
+		<path id="path2557" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M137.145,323.764v5.131"/>
+		<path id="path2559" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M140.33,323.764v5.131"/>
+		<path id="path2561" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M143.514,323.764v5.131"/>
+		<path id="path2567" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M179.096,157.173v173.813"/>
+		<path id="path2565" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M182.12,159.266v5.131"/>
+		<path id="path2569" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M185.303,159.266v5.131"/>
+		<path id="path2571" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M188.488,159.266v5.131"/>
+		<path id="path2573" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M191.672,159.266v5.131"/>
+		<path id="path2591" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M182.12,323.764v5.131"/>
+		<path id="path2593" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M185.303,323.764v5.131"/>
+		<path id="path2595" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M188.488,323.764v5.131"/>
+		<path id="path2597" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M191.672,323.764v5.131"/>
+		<path id="path2603" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M162.827,157.173v173.813"/>
+		<path id="path2601" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M165.851,159.266v5.131"/>
+		<path id="path2605" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M169.036,159.266v5.131"/>
+		<path id="path2607" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M172.219,159.266v5.131"/>
+		<path id="path2609" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M175.403,159.266v5.131"/>
+		<path id="path2627" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M165.851,323.764v5.131"/>
+		<path id="path2629" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M169.036,323.764v5.131"/>
+		<path id="path2631" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M172.219,323.764v5.131"/>
+		<path id="path2633" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M175.403,323.764v5.131"/>
+		<path id="path2639" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M210.985,157.173v173.813"/>
+		<path id="path2637" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M214.009,159.266v5.131"/>
+		<path id="path2641" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M217.194,159.266v5.131"/>
+		<path id="path2643" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M220.378,159.266v5.131"/>
+		<path id="path2645" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M223.561,159.266v5.131"/>
+		<path id="path2663" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M214.009,323.764v5.131"/>
+		<path id="path2665" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M217.194,323.764v5.131"/>
+		<path id="path2667" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M220.378,323.764v5.131"/>
+		<path id="path2669" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M223.561,323.764v5.131"/>
+		<path id="path2675" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M194.717,157.173v173.813"/>
+		<path id="path2673" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M197.741,159.266v5.131"/>
+		<path id="path2677" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M200.924,159.266v5.131"/>
+		<path id="path2679" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M204.109,159.266v5.131"/>
+		<path id="path2681" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M207.294,159.266v5.131"/>
+		<path id="path2699" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M197.741,323.764v5.131"/>
+		<path id="path2701" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M200.924,323.764v5.131"/>
+		<path id="path2703" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M204.109,323.764v5.131"/>
+		<path id="path2705" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M207.294,323.764v5.131"/>
+		<path id="path2711" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M242.876,157.173v173.813"/>
+		<path id="path2709" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M245.899,159.266v5.131"/>
+		<path id="path2713" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M249.084,159.266v5.131"/>
+		<path id="path2715" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M252.268,159.266v5.131"/>
+		<path id="path2717" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M255.452,159.266v5.131"/>
+		<path id="path2735" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M245.899,323.764v5.131"/>
+		<path id="path2737" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M249.084,323.764v5.131"/>
+		<path id="path2739" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M252.268,323.764v5.131"/>
+		<path id="path2741" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M255.452,323.764v5.131"/>
+		<path id="path2747" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M226.607,157.173v173.813"/>
+		<path id="path2745" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M229.63,159.266v5.131"/>
+		<path id="path2749" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M232.815,159.266v5.131"/>
+		<path id="path2751" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M235.999,159.266v5.131"/>
+		<path id="path2753" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M239.183,159.266v5.131"/>
+		<path id="path2771" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M229.63,323.764v5.131"/>
+		<path id="path2773" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M232.815,323.764v5.131"/>
+		<path id="path2775" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M235.999,323.764v5.131"/>
+		<path id="path2777" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M239.183,323.764v5.131"/>
+		<path id="path2783" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M274.765,157.173v173.813"/>
+		<path id="path2781" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M277.79,159.266v5.131"/>
+		<path id="path2785" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M280.973,159.266v5.131"/>
+		<path id="path2787" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M284.157,159.266v5.131"/>
+		<path id="path2789" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M287.341,159.266v5.131"/>
+		<path id="path2807" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M277.79,323.764v5.131"/>
+		<path id="path2809" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M280.973,323.764v5.131"/>
+		<path id="path2811" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M284.157,323.764v5.131"/>
+		<path id="path2813" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M287.341,323.764v5.131"/>
+		<path id="path2819" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M258.497,157.173v173.813"/>
+		<path id="path2817" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M261.52,159.266v5.131"/>
+		<path id="path2821" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M264.705,159.266v5.131"/>
+		<path id="path2823" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M267.889,159.266v5.131"/>
+		<path id="path2825" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M271.073,159.266v5.131"/>
+		<path id="path2843" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M261.52,323.764v5.131"/>
+		<path id="path2845" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M264.705,323.764v5.131"/>
+		<path id="path2847" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M267.889,323.764v5.131"/>
+		<path id="path2849" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M271.073,323.764v5.131"/>
+		<path id="path2855" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M306.655,157.173v173.813"/>
+		<path id="path2853" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M309.678,159.266v5.131"/>
+		<path id="path2857" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M312.863,159.266v5.131"/>
+		<path id="path2859" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M316.047,159.266v5.131"/>
+		<path id="path2861" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M319.231,159.266v5.131"/>
+		<path id="path2879" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M309.678,323.764v5.131"/>
+		<path id="path2881" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M312.863,323.764v5.131"/>
+		<path id="path2883" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M316.047,323.764v5.131"/>
+		<path id="path2885" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M319.231,323.764v5.131"/>
+		<path id="path2891" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M290.386,157.173v173.813"/>
+		<path id="path2889" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M293.411,159.266v5.131"/>
+		<path id="path2893" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M296.594,159.266v5.131"/>
+		<path id="path2895" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M299.778,159.266v5.131"/>
+		<path id="path2897" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M302.963,159.266v5.131"/>
+		<g id="g5861" transform="translate(0,56.02796)">
+			<path id="path2196" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M22.671,210.289v5.131"/>
+			<path id="path2198" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M25.855,210.289v5.131"/>
+			<path id="path2200" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M29.039,210.289v5.131"/>
+			<path id="path2202" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M32.223,210.289v5.131"/>
+			<path id="path2251" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M6.402,210.289v5.131"/>
+			<path id="path2253" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M9.587,210.289v5.131"/>
+			<path id="path2255" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M12.771,210.289v5.131"/>
+			<path id="path2257" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M15.955,210.289v5.131"/>
+			<path id="path2287" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M54.561,210.289v5.131"/>
+			<path id="path2289" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M57.745,210.289v5.131"/>
+			<path id="path2291" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M60.929,210.289v5.131"/>
+			<path id="path2293" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M64.113,210.289v5.131"/>
+			<path id="path2323" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M38.292,210.289v5.131"/>
+			<path id="path2325" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M41.476,210.289v5.131"/>
+			<path id="path2327" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M44.66,210.289v5.131"/>
+			<path id="path2329" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M47.844,210.289v5.131"/>
+			<path id="path2359" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M86.45,210.289v5.131"/>
+			<path id="path2361" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M89.634,210.289v5.131"/>
+			<path id="path2363" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M92.818,210.289v5.131"/>
+			<path id="path2365" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M96.003,210.289v5.131"/>
+			<path id="path2395" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M70.182,210.289v5.131"/>
+			<path id="path2397" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M73.366,210.289v5.131"/>
+			<path id="path2399" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M76.55,210.289v5.131"/>
+			<path id="path2401" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M79.734,210.289v5.131"/>
+			<path id="path2431" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M118.34,210.289v5.131"/>
+			<path id="path2433" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M121.525,210.289v5.131"/>
+			<path id="path2435" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M124.709,210.289v5.131"/>
+			<path id="path2437" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M127.893,210.289v5.131"/>
+			<path id="path2467" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M102.071,210.289v5.131"/>
+			<path id="path2469" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M105.256,210.289v5.131"/>
+			<path id="path2471" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M108.44,210.289v5.131"/>
+			<path id="path2473" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M111.624,210.289v5.131"/>
+			<path id="path2503" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M150.23,210.289v5.131"/>
+			<path id="path2505" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M153.415,210.289v5.131"/>
+			<path id="path2507" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M156.598,210.289v5.131"/>
+			<path id="path2509" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M159.782,210.289v5.131"/>
+			<path id="path2539" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M133.962,210.289v5.131"/>
+			<path id="path2541" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M137.145,210.289v5.131"/>
+			<path id="path2543" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M140.33,210.289v5.131"/>
+			<path id="path2545" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M143.514,210.289v5.131"/>
+			<path id="path2575" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M182.12,210.289v5.131"/>
+			<path id="path2577" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M185.303,210.289v5.131"/>
+			<path id="path2579" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M188.488,210.289v5.131"/>
+			<path id="path2581" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M191.672,210.289v5.131"/>
+			<path id="path2611" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M165.851,210.289v5.131"/>
+			<path id="path2613" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M169.036,210.289v5.131"/>
+			<path id="path2615" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M172.219,210.289v5.131"/>
+			<path id="path2617" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M175.403,210.289v5.131"/>
+			<path id="path2647" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M214.009,210.289v5.131"/>
+			<path id="path2649" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M217.194,210.289v5.131"/>
+			<path id="path2651" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M220.378,210.289v5.131"/>
+			<path id="path2653" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M223.561,210.289v5.131"/>
+			<path id="path2683" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M197.741,210.289v5.131"/>
+			<path id="path2685" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M200.924,210.289v5.131"/>
+			<path id="path2687" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M204.109,210.289v5.131"/>
+			<path id="path2689" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M207.294,210.289v5.131"/>
+			<path id="path2719" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M245.899,210.289v5.131"/>
+			<path id="path2721" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M249.084,210.289v5.131"/>
+			<path id="path2723" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M252.268,210.289v5.131"/>
+			<path id="path2725" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M255.452,210.289v5.131"/>
+			<path id="path2755" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M229.63,210.289v5.131"/>
+			<path id="path2757" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M232.815,210.289v5.131"/>
+			<path id="path2759" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M235.999,210.289v5.131"/>
+			<path id="path2761" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M239.183,210.289v5.131"/>
+			<path id="path2791" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M277.79,210.289v5.131"/>
+			<path id="path2793" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M280.973,210.289v5.131"/>
+			<path id="path2795" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M284.157,210.289v5.131"/>
+			<path id="path2797" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M287.341,210.289v5.131"/>
+			<path id="path2827" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M261.52,210.289v5.131"/>
+			<path id="path2829" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M264.705,210.289v5.131"/>
+			<path id="path2831" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M267.889,210.289v5.131"/>
+			<path id="path2833" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M271.073,210.289v5.131"/>
+			<path id="path2863" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M309.678,210.289v5.131"/>
+			<path id="path2865" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M312.863,210.289v5.131"/>
+			<path id="path2867" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M316.047,210.289v5.131"/>
+			<path id="path2869" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M319.231,210.289v5.131"/>
+			<path id="path2899" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M293.411,210.289v5.131"/>
+			<path id="path2901" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M296.594,210.289v5.131"/>
+			<path id="path2903" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M299.778,210.289v5.131"/>
+			<path id="path2905" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M302.963,210.289v5.131"/>
+		</g>
+		<g id="g5943" transform="translate(0,-56.02915)">
+			<path id="path2204" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M22.671,272.741v5.131"/>
+			<path id="path2206" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M25.855,272.741v5.131"/>
+			<path id="path2208" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M29.039,272.741v5.131"/>
+			<path id="path2210" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M32.223,272.741v5.131"/>
+			<path id="path2259" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M6.402,272.741v5.131"/>
+			<path id="path2261" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M9.587,272.741v5.131"/>
+			<path id="path2263" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M12.771,272.741v5.131"/>
+			<path id="path2265" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M15.955,272.741v5.131"/>
+			<path id="path2295" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M54.561,272.741v5.131"/>
+			<path id="path2297" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M57.745,272.741v5.131"/>
+			<path id="path2299" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M60.929,272.741v5.131"/>
+			<path id="path2301" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M64.113,272.741v5.131"/>
+			<path id="path2331" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M38.292,272.741v5.131"/>
+			<path id="path2333" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M41.476,272.741v5.131"/>
+			<path id="path2335" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M44.66,272.741v5.131"/>
+			<path id="path2337" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M47.844,272.741v5.131"/>
+			<path id="path2367" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M86.45,272.741v5.131"/>
+			<path id="path2369" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M89.634,272.741v5.131"/>
+			<path id="path2371" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M92.818,272.741v5.131"/>
+			<path id="path2373" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M96.003,272.741v5.131"/>
+			<path id="path2403" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M70.182,272.741v5.131"/>
+			<path id="path2405" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M73.366,272.741v5.131"/>
+			<path id="path2407" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M76.55,272.741v5.131"/>
+			<path id="path2409" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M79.734,272.741v5.131"/>
+			<path id="path2439" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M118.34,272.741v5.131"/>
+			<path id="path2441" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M121.525,272.741v5.131"/>
+			<path id="path2443" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M124.709,272.741v5.131"/>
+			<path id="path2445" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M127.893,272.741v5.131"/>
+			<path id="path2475" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M102.071,272.741v5.131"/>
+			<path id="path2477" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M105.255,272.741v5.131"/>
+			<path id="path2479" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M108.44,272.741v5.131"/>
+			<path id="path2481" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M111.624,272.741v5.131"/>
+			<path id="path2511" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M150.23,272.741v5.131"/>
+			<path id="path2513" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M153.415,272.741v5.131"/>
+			<path id="path2515" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M156.598,272.741v5.131"/>
+			<path id="path2517" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M159.782,272.741v5.131"/>
+			<path id="path2547" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M133.962,272.741v5.131"/>
+			<path id="path2549" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M137.145,272.741v5.131"/>
+			<path id="path2551" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M140.33,272.741v5.131"/>
+			<path id="path2553" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M143.514,272.741v5.131"/>
+			<path id="path2583" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M182.12,272.741v5.131"/>
+			<path id="path2585" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M185.303,272.741v5.131"/>
+			<path id="path2587" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M188.488,272.741v5.131"/>
+			<path id="path2589" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M191.672,272.741v5.131"/>
+			<path id="path2619" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M165.851,272.741v5.131"/>
+			<path id="path2621" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M169.036,272.741v5.131"/>
+			<path id="path2623" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M172.219,272.741v5.131"/>
+			<path id="path2625" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M175.403,272.741v5.131"/>
+			<path id="path2655" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M214.009,272.741v5.131"/>
+			<path id="path2657" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M217.194,272.741v5.131"/>
+			<path id="path2659" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M220.378,272.741v5.131"/>
+			<path id="path2661" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M223.561,272.741v5.131"/>
+			<path id="path2691" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M197.741,272.741v5.131"/>
+			<path id="path2693" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M200.924,272.741v5.131"/>
+			<path id="path2695" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M204.109,272.741v5.131"/>
+			<path id="path2697" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M207.294,272.741v5.131"/>
+			<path id="path2727" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M245.899,272.741v5.131"/>
+			<path id="path2729" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M249.084,272.741v5.131"/>
+			<path id="path2731" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M252.268,272.741v5.131"/>
+			<path id="path2733" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M255.452,272.741v5.131"/>
+			<path id="path2763" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M229.63,272.741v5.131"/>
+			<path id="path2765" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M232.815,272.741v5.131"/>
+			<path id="path2767" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M235.999,272.741v5.131"/>
+			<path id="path2769" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M239.183,272.741v5.131"/>
+			<path id="path2799" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M277.79,272.741v5.131"/>
+			<path id="path2801" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M280.973,272.741v5.131"/>
+			<path id="path2803" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M284.157,272.741v5.131"/>
+			<path id="path2805" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M287.341,272.741v5.131"/>
+			<path id="path2835" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M261.52,272.741v5.131"/>
+			<path id="path2837" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M264.705,272.741v5.131"/>
+			<path id="path2839" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M267.889,272.741v5.131"/>
+			<path id="path2841" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M271.073,272.741v5.131"/>
+			<path id="path2871" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M309.678,272.741v5.131"/>
+			<path id="path2873" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M312.863,272.741v5.131"/>
+			<path id="path2875" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M316.047,272.741v5.131"/>
+			<path id="path2877" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M319.231,272.741v5.131"/>
+			<path id="path2907" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M293.411,272.741v5.131"/>
+			<path id="path2909" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M296.594,272.741v5.131"/>
+			<path id="path2911" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M299.778,272.741v5.131"/>
+			<path id="path2913" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M302.963,272.741v5.131"/>
+		</g>
+		<path id="path2915" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M293.411,323.764v5.131"/>
+		<path id="path2917" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M296.594,323.764v5.131"/>
+		<path id="path2919" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M299.778,323.764v5.131"/>
+		<path id="path2921" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M302.963,323.764v5.131"/>
+		<path id="path2940" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M9.741,239.282v9.598"/>
+		<path id="path2945" fill="none" stroke="#FFFFFF" stroke-width="0.8858" d="M315.882,239.282v9.598"/>
+		<g id="g2951" transform="translate(-7.706525,36.41094)">
+			<path id="path2947" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M-23.371,224.412h4.777"/>
+			<path id="path2949" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M-23.371,190.927h4.777"/>
+		</g>
+		<g id="g2955" transform="translate(374.9706,36.41094)">
+			<path id="path2957" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M-23.37,224.412h4.777"/>
+			<path id="path2959" fill="none" stroke="#FFFFFF" stroke-width="1.3333" d="M-23.37,190.927h4.777"/>
+		</g>
+	</g>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="1.25" stroke-linecap="square" x1="13.831" y1="237.968" x2="4.434" y2="234.547"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="1.25" stroke-linecap="square" x1="13.831" y1="271.453" x2="4.434" y2="274.873"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="1.25" stroke-linecap="square" x1="333.083" y1="237.968" x2="342.48" y2="234.547"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="1.25" stroke-linecap="square" x1="333.083" y1="271.453" x2="342.48" y2="274.873"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="1.25" stroke-linecap="square" x1="337.782" y1="236.257" x2="337.782" y2="273.162"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="1.25" stroke-linecap="square" x1="9.133" y1="236.257" x2="9.133" y2="273.162"/>
+</g>
+<g id="layer2" sodipodi:insensitive="true" inkscape:label="numbers" inkscape:groupmode="layer">
+	<g id="g6379" transform="translate(10.45445,10.61265)">
+		<g id="g4580" transform="translate(0.353208,0)">
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M32.099,309.492h-2.195v-8.273c-0.802,0.75-1.748,1.305-2.836,1.664v-1.992
+					c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.133,1.383-1.832h1.781V309.492z"/>
+				<path fill="#FFFFFF" d="M39.091,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C37.117,298.383,37.981,297.992,39.091,297.992z
+					 M39.091,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C39.592,299.899,39.356,299.813,39.091,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M32.099,309.492h-2.195v-8.273
+					c-0.802,0.75-1.748,1.305-2.836,1.664v-1.992c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.133,1.383-1.832h1.781V309.492z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M39.091,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C37.117,298.383,37.981,297.992,39.091,297.992z M39.091,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C39.592,299.899,39.356,299.813,39.091,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M65.785,307.453v2.039H58.09c0.083-0.77,0.333-1.5,0.75-2.191c0.417-0.689,1.239-1.605,2.469-2.746
+					c0.989-0.922,1.596-1.547,1.82-1.875c0.302-0.453,0.453-0.9,0.453-1.344c0-0.488-0.132-0.865-0.395-1.129
+					c-0.263-0.262-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.139-1.094,0.414c-0.271,0.277-0.427,0.734-0.469,1.375l-2.188-0.219
+					c0.13-1.207,0.539-2.074,1.227-2.602c0.688-0.525,1.547-0.789,2.578-0.789c1.13,0,2.018,0.305,2.664,0.914
+					c0.646,0.609,0.969,1.367,0.969,2.273c0,0.516-0.093,1.008-0.277,1.473c-0.185,0.467-0.478,0.955-0.879,1.465
+					c-0.266,0.34-0.745,0.826-1.438,1.461c-0.693,0.637-1.132,1.059-1.316,1.266c-0.185,0.209-0.335,0.412-0.449,0.609H65.785z"/>
+				<path fill="#FFFFFF" d="M70.98,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C69.006,298.383,69.871,297.992,70.98,297.992z
+					 M70.98,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C71.481,299.899,71.246,299.813,70.98,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M65.785,307.453v2.039H58.09c0.083-0.77,0.333-1.5,0.75-2.191
+					c0.417-0.689,1.239-1.605,2.469-2.746c0.989-0.922,1.596-1.547,1.82-1.875c0.302-0.453,0.453-0.9,0.453-1.344
+					c0-0.488-0.132-0.865-0.395-1.129c-0.263-0.262-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.139-1.094,0.414
+					c-0.271,0.277-0.427,0.734-0.469,1.375l-2.188-0.219c0.13-1.207,0.539-2.074,1.227-2.602c0.688-0.525,1.547-0.789,2.578-0.789
+					c1.13,0,2.018,0.305,2.664,0.914c0.646,0.609,0.969,1.367,0.969,2.273c0,0.516-0.093,1.008-0.277,1.473
+					c-0.185,0.467-0.478,0.955-0.879,1.465c-0.266,0.34-0.745,0.826-1.438,1.461c-0.693,0.637-1.132,1.059-1.316,1.266
+					c-0.185,0.209-0.335,0.412-0.449,0.609H65.785z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M70.98,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C69.006,298.383,69.871,297.992,70.98,297.992z M70.98,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C71.481,299.899,71.246,299.813,70.98,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M90.183,306.453l2.125-0.258c0.067,0.543,0.25,0.957,0.547,1.242c0.297,0.287,0.656,0.43,1.078,0.43
+					c0.453,0,0.834-0.172,1.145-0.516c0.31-0.344,0.465-0.807,0.465-1.391c0-0.551-0.148-0.988-0.445-1.312
+					c-0.297-0.322-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789c0.594,0.016,1.047-0.113,1.359-0.387
+					s0.469-0.637,0.469-1.09c0-0.385-0.115-0.691-0.344-0.922c-0.229-0.229-0.534-0.344-0.914-0.344
+					c-0.375,0-0.695,0.131-0.961,0.391c-0.266,0.262-0.427,0.641-0.484,1.141l-2.023-0.344c0.141-0.691,0.353-1.246,0.637-1.66
+					c0.284-0.414,0.68-0.738,1.188-0.977c0.508-0.236,1.077-0.355,1.707-0.355c1.078,0,1.942,0.344,2.594,1.031
+					c0.536,0.562,0.805,1.199,0.805,1.906c0,1.006-0.55,1.809-1.648,2.406c0.656,0.141,1.181,0.457,1.574,0.945
+					c0.393,0.49,0.59,1.082,0.59,1.773c0,1.006-0.367,1.863-1.102,2.57c-0.734,0.709-1.648,1.062-2.742,1.062
+					c-1.037,0-1.896-0.297-2.578-0.895C90.687,308.197,90.292,307.418,90.183,306.453z"/>
+				<path fill="#FFFFFF" d="M102.87,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C100.896,298.383,101.761,297.992,102.87,297.992z
+					 M102.87,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C103.371,299.899,103.136,299.813,102.87,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M90.183,306.453l2.125-0.258c0.067,0.543,0.25,0.957,0.547,1.242
+					c0.297,0.287,0.656,0.43,1.078,0.43c0.453,0,0.834-0.172,1.145-0.516c0.31-0.344,0.465-0.807,0.465-1.391
+					c0-0.551-0.148-0.988-0.445-1.312c-0.297-0.322-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789
+					c0.594,0.016,1.047-0.113,1.359-0.387s0.469-0.637,0.469-1.09c0-0.385-0.115-0.691-0.344-0.922
+					c-0.229-0.229-0.534-0.344-0.914-0.344c-0.375,0-0.695,0.131-0.961,0.391c-0.266,0.262-0.427,0.641-0.484,1.141l-2.023-0.344
+					c0.141-0.691,0.353-1.246,0.637-1.66c0.284-0.414,0.68-0.738,1.188-0.977c0.508-0.236,1.077-0.355,1.707-0.355
+					c1.078,0,1.942,0.344,2.594,1.031c0.536,0.562,0.805,1.199,0.805,1.906c0,1.006-0.55,1.809-1.648,2.406
+					c0.656,0.141,1.181,0.457,1.574,0.945c0.393,0.49,0.59,1.082,0.59,1.773c0,1.006-0.367,1.863-1.102,2.57
+					c-0.734,0.709-1.648,1.062-2.742,1.062c-1.037,0-1.896-0.297-2.578-0.895C90.687,308.197,90.292,307.418,90.183,306.453z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M102.87,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C100.896,298.383,101.761,297.992,102.87,297.992z M102.87,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C103.371,299.899,103.136,299.813,102.87,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M126.455,309.492v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266h1.422v1.93h-1.422v2.305H126.455z
+					 M126.455,305.258v-3.914l-2.633,3.914H126.455z"/>
+				<path fill="#FFFFFF" d="M134.76,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C132.786,298.383,133.65,297.992,134.76,297.992z
+					 M134.76,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C135.261,299.899,135.025,299.813,134.76,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M126.455,309.492v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266
+					h1.422v1.93h-1.422v2.305H126.455z M126.455,305.258v-3.914l-2.633,3.914H126.455z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M134.76,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C132.786,298.383,133.65,297.992,134.76,297.992z M134.76,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.135,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C135.261,299.899,135.025,299.813,134.76,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M154.072,306.547l2.188-0.227c0.062,0.496,0.247,0.887,0.555,1.176c0.307,0.289,0.661,0.434,1.062,0.434
+					c0.458,0,0.846-0.186,1.164-0.559c0.317-0.371,0.477-0.934,0.477-1.684c0-0.703-0.158-1.23-0.473-1.582
+					c-0.315-0.352-0.726-0.527-1.23-0.527c-0.631,0-1.195,0.279-1.695,0.836l-1.781-0.258l1.125-5.961h5.805v2.055h-4.141
+					l-0.344,1.945c0.489-0.244,0.989-0.367,1.5-0.367c0.974,0,1.799,0.355,2.477,1.062c0.677,0.709,1.016,1.629,1.016,2.758
+					c0,0.943-0.273,1.785-0.82,2.523c-0.745,1.012-1.779,1.516-3.102,1.516c-1.058,0-1.92-0.283-2.586-0.852
+					C154.6,308.27,154.202,307.506,154.072,306.547z"/>
+				<path fill="#FFFFFF" d="M166.65,297.992c1.109,0,1.977,0.396,2.602,1.188c0.744,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.014-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C164.675,298.383,165.54,297.992,166.65,297.992z
+					 M166.65,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.209,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.135,0.504,0.306,0.838,0.512,1.004c0.205,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.369-0.473,0.484-0.91c0.15-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.307-0.838-0.512-1.008C167.151,299.899,166.915,299.813,166.65,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M154.072,306.547l2.188-0.227c0.062,0.496,0.247,0.887,0.555,1.176
+					c0.307,0.289,0.661,0.434,1.062,0.434c0.458,0,0.846-0.186,1.164-0.559c0.317-0.371,0.477-0.934,0.477-1.684
+					c0-0.703-0.158-1.23-0.473-1.582c-0.315-0.352-0.726-0.527-1.23-0.527c-0.631,0-1.195,0.279-1.695,0.836l-1.781-0.258
+					l1.125-5.961h5.805v2.055h-4.141l-0.344,1.945c0.489-0.244,0.989-0.367,1.5-0.367c0.974,0,1.799,0.355,2.477,1.062
+					c0.677,0.709,1.016,1.629,1.016,2.758c0,0.943-0.273,1.785-0.82,2.523c-0.745,1.012-1.779,1.516-3.102,1.516
+					c-1.058,0-1.92-0.283-2.586-0.852C154.6,308.27,154.202,307.506,154.072,306.547z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M166.65,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.744,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.014-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C164.675,298.383,165.54,297.992,166.65,297.992z M166.65,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.209,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.135,0.504,0.306,0.838,0.512,1.004c0.205,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.369-0.473,0.484-0.91c0.15-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.307-0.838-0.512-1.008C167.151,299.899,166.915,299.813,166.65,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M190.235,309.492v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266h1.422v1.93h-1.422v2.305H190.235z
+					 M190.235,305.258v-3.914l-2.633,3.914H190.235z"/>
+				<path fill="#FFFFFF" d="M198.539,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C196.566,298.383,197.43,297.992,198.539,297.992z
+					 M198.539,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.136,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.503-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C199.04,299.899,198.805,299.813,198.539,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M190.235,309.492v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266
+					h1.422v1.93h-1.422v2.305H190.235z M190.235,305.258v-3.914l-2.633,3.914H190.235z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M198.539,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C196.566,298.383,197.43,297.992,198.539,297.992z M198.539,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.136,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.503-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C199.04,299.899,198.805,299.813,198.539,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M217.742,306.453l2.125-0.258c0.067,0.543,0.25,0.957,0.547,1.242c0.297,0.287,0.656,0.43,1.078,0.43
+					c0.453,0,0.834-0.172,1.145-0.516c0.31-0.344,0.465-0.807,0.465-1.391c0-0.551-0.148-0.988-0.445-1.312
+					c-0.297-0.322-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789c0.594,0.016,1.047-0.113,1.359-0.387
+					s0.469-0.637,0.469-1.09c0-0.385-0.115-0.691-0.344-0.922c-0.229-0.229-0.534-0.344-0.914-0.344
+					c-0.375,0-0.695,0.131-0.961,0.391c-0.266,0.262-0.428,0.641-0.484,1.141l-2.023-0.344c0.141-0.691,0.353-1.246,0.637-1.66
+					c0.283-0.414,0.68-0.738,1.188-0.977c0.508-0.236,1.076-0.355,1.707-0.355c1.078,0,1.942,0.344,2.594,1.031
+					c0.536,0.562,0.805,1.199,0.805,1.906c0,1.006-0.55,1.809-1.648,2.406c0.656,0.141,1.181,0.457,1.574,0.945
+					c0.393,0.49,0.59,1.082,0.59,1.773c0,1.006-0.367,1.863-1.102,2.57c-0.734,0.709-1.648,1.062-2.742,1.062
+					c-1.037,0-1.896-0.297-2.578-0.895C218.247,308.197,217.851,307.418,217.742,306.453z"/>
+				<path fill="#FFFFFF" d="M230.429,297.992c1.109,0,1.977,0.396,2.602,1.188c0.744,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.014-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C228.455,298.383,229.32,297.992,230.429,297.992z
+					 M230.429,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.209,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.135,0.504,0.306,0.838,0.512,1.004c0.205,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.369-0.473,0.484-0.91c0.15-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.307-0.838-0.512-1.008C230.93,299.899,230.695,299.813,230.429,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M217.742,306.453l2.125-0.258c0.067,0.543,0.25,0.957,0.547,1.242
+					c0.297,0.287,0.656,0.43,1.078,0.43c0.453,0,0.834-0.172,1.145-0.516c0.31-0.344,0.465-0.807,0.465-1.391
+					c0-0.551-0.148-0.988-0.445-1.312c-0.297-0.322-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789
+					c0.594,0.016,1.047-0.113,1.359-0.387s0.469-0.637,0.469-1.09c0-0.385-0.115-0.691-0.344-0.922
+					c-0.229-0.229-0.534-0.344-0.914-0.344c-0.375,0-0.695,0.131-0.961,0.391c-0.266,0.262-0.428,0.641-0.484,1.141l-2.023-0.344
+					c0.141-0.691,0.353-1.246,0.637-1.66c0.283-0.414,0.68-0.738,1.188-0.977c0.508-0.236,1.076-0.355,1.707-0.355
+					c1.078,0,1.942,0.344,2.594,1.031c0.536,0.562,0.805,1.199,0.805,1.906c0,1.006-0.55,1.809-1.648,2.406
+					c0.656,0.141,1.181,0.457,1.574,0.945c0.393,0.49,0.59,1.082,0.59,1.773c0,1.006-0.367,1.863-1.102,2.57
+					c-0.734,0.709-1.648,1.062-2.742,1.062c-1.037,0-1.896-0.297-2.578-0.895C218.247,308.197,217.851,307.418,217.742,306.453z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M230.429,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.744,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.014-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C228.455,298.383,229.32,297.992,230.429,297.992z M230.429,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.209,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.135,0.504,0.306,0.838,0.512,1.004c0.205,0.168,0.441,0.25,0.707,0.25s0.502-0.084,0.711-0.254
+					c0.208-0.168,0.369-0.473,0.484-0.91c0.15-0.562,0.227-1.516,0.227-2.859s-0.068-2.266-0.203-2.77
+					c-0.136-0.502-0.307-0.838-0.512-1.008C230.93,299.899,230.695,299.813,230.429,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M257.123,307.453v2.039h-7.695c0.083-0.77,0.333-1.5,0.75-2.191c0.417-0.689,1.239-1.605,2.469-2.746
+					c0.989-0.922,1.597-1.547,1.82-1.875c0.302-0.453,0.453-0.9,0.453-1.344c0-0.488-0.132-0.865-0.395-1.129
+					c-0.263-0.262-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.139-1.094,0.414c-0.271,0.277-0.427,0.734-0.469,1.375l-2.188-0.219
+					c0.13-1.207,0.539-2.074,1.227-2.602c0.688-0.525,1.547-0.789,2.578-0.789c1.13,0,2.019,0.305,2.664,0.914
+					s0.969,1.367,0.969,2.273c0,0.516-0.093,1.008-0.277,1.473c-0.185,0.467-0.478,0.955-0.879,1.465
+					c-0.266,0.34-0.745,0.826-1.438,1.461c-0.692,0.637-1.132,1.059-1.316,1.266c-0.185,0.209-0.335,0.412-0.449,0.609H257.123z"/>
+				<path fill="#FFFFFF" d="M262.319,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.428-2.695-1.285
+					c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C260.345,298.383,261.209,297.992,262.319,297.992z
+					 M262.319,299.813c-0.266,0-0.503,0.086-0.711,0.254c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867
+					s0.067,2.268,0.203,2.77c0.136,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.503-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C262.82,299.899,262.584,299.813,262.319,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M257.123,307.453v2.039h-7.695c0.083-0.77,0.333-1.5,0.75-2.191
+					c0.417-0.689,1.239-1.605,2.469-2.746c0.989-0.922,1.597-1.547,1.82-1.875c0.302-0.453,0.453-0.9,0.453-1.344
+					c0-0.488-0.132-0.865-0.395-1.129c-0.263-0.262-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.139-1.094,0.414
+					c-0.271,0.277-0.427,0.734-0.469,1.375l-2.188-0.219c0.13-1.207,0.539-2.074,1.227-2.602c0.688-0.525,1.547-0.789,2.578-0.789
+					c1.13,0,2.019,0.305,2.664,0.914s0.969,1.367,0.969,2.273c0,0.516-0.093,1.008-0.277,1.473
+					c-0.185,0.467-0.478,0.955-0.879,1.465c-0.266,0.34-0.745,0.826-1.438,1.461c-0.692,0.637-1.132,1.059-1.316,1.266
+					c-0.185,0.209-0.335,0.412-0.449,0.609H257.123z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M262.319,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.428-2.695-1.285c-0.683-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C260.345,298.383,261.209,297.992,262.319,297.992z M262.319,299.813c-0.266,0-0.503,0.086-0.711,0.254
+					c-0.208,0.17-0.37,0.473-0.484,0.91c-0.151,0.568-0.227,1.523-0.227,2.867s0.067,2.268,0.203,2.77
+					c0.136,0.504,0.306,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.503-0.084,0.711-0.254
+					c0.208-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.266-0.203-2.77
+					c-0.136-0.502-0.306-0.838-0.512-1.008C262.82,299.899,262.584,299.813,262.319,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M287.216,309.492h-2.195v-8.273c-0.802,0.75-1.747,1.305-2.836,1.664v-1.992
+					c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.133,1.383-1.832h1.781V309.492z"/>
+				<path fill="#FFFFFF" d="M294.208,297.992c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.168-0.375,3.725-1.125,4.672c-0.619,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.428-2.695-1.285
+					c-0.682-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656C292.235,298.383,293.099,297.992,294.208,297.992z
+					 M294.208,299.813c-0.266,0-0.502,0.086-0.711,0.254c-0.208,0.17-0.369,0.473-0.484,0.91c-0.15,0.568-0.227,1.523-0.227,2.867
+					s0.068,2.268,0.203,2.77c0.136,0.504,0.307,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.503-0.084,0.711-0.254
+					c0.209-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.266-0.203-2.77
+					c-0.135-0.502-0.306-0.838-0.512-1.008C294.71,299.899,294.474,299.813,294.208,299.813z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M287.216,309.492h-2.195v-8.273
+					c-0.802,0.75-1.747,1.305-2.836,1.664v-1.992c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.133,1.383-1.832h1.781V309.492z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M294.208,297.992c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.168-0.375,3.725-1.125,4.672c-0.619,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.428-2.695-1.285c-0.682-0.855-1.023-2.383-1.023-4.582c0-2.156,0.375-3.707,1.125-4.656
+					C292.235,298.383,293.099,297.992,294.208,297.992z M294.208,299.813c-0.266,0-0.502,0.086-0.711,0.254
+					c-0.208,0.17-0.369,0.473-0.484,0.91c-0.15,0.568-0.227,1.523-0.227,2.867s0.068,2.268,0.203,2.77
+					c0.136,0.504,0.307,0.838,0.512,1.004c0.206,0.168,0.441,0.25,0.707,0.25s0.503-0.084,0.711-0.254
+					c0.209-0.168,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.266-0.203-2.77
+					c-0.135-0.502-0.306-0.838-0.512-1.008C294.71,299.899,294.474,299.813,294.208,299.813z"/>
+			</g>
+			<g id="g4564">
+				
+					<path id="path3683" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M20.483,303.537l3.978-1.148v2.297L20.483,303.537z"/>
+				
+					<path id="path4558" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M52.372,303.537l3.978-1.148v2.297L52.372,303.537z"/>
+				
+					<path id="path4560" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M84.262,303.537l3.978-1.148v2.297L84.262,303.537z"/>
+				
+					<path id="path4562" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M116.151,303.537l3.978-1.148v2.297L116.151,303.537z"/>
+			</g>
+			<g id="g4570" transform="matrix(-1,0,0,1,383.739,0)">
+				
+					<path id="path4572" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M77.86,303.537l3.979-1.148v2.297L77.86,303.537z"/>
+				
+					<path id="path4574" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M109.748,303.537l3.979-1.148v2.297L109.748,303.537z"/>
+				
+					<path id="path4576" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M141.639,303.537l3.978-1.148v2.297L141.639,303.537z"/>
+				
+					<path id="path4578" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M173.528,303.537l3.979-1.148v2.297L173.528,303.537z"/>
+			</g>
+		</g>
+		<g id="g4610" transform="matrix(-1,0,0,-1,382.6749,173.6566)">
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M89.476-5.045H87.28v-8.273c-0.802,0.75-1.747,1.305-2.836,1.664v-1.992
+					c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.134,1.383-1.832h1.781V-5.045z"/>
+				<path fill="#FFFFFF" d="M96.468-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.429-2.695-1.285
+					s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C94.494-16.154,95.358-16.545,96.468-16.545z M96.468-14.724
+					c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91
+					c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77s-0.306-0.839-0.512-1.008S96.733-14.724,96.468-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M89.476-5.045H87.28v-8.273c-0.802,0.75-1.747,1.305-2.836,1.664
+					v-1.992c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.134,1.383-1.832h1.781V-5.045z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M96.468-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.429-2.695-1.285s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C94.494-16.154,95.358-16.545,96.468-16.545z M96.468-14.724c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91
+					c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25
+					s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77
+					s-0.306-0.839-0.512-1.008S96.733-14.724,96.468-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M123.161-7.084v2.039h-7.695c0.083-0.771,0.333-1.501,0.75-2.191s1.239-1.605,2.469-2.746
+					c0.989-0.922,1.597-1.547,1.82-1.875c0.302-0.453,0.453-0.901,0.453-1.344c0-0.489-0.132-0.866-0.395-1.129
+					s-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.138-1.094,0.414s-0.427,0.734-0.469,1.375l-2.188-0.219
+					c0.13-1.208,0.539-2.075,1.227-2.602s1.547-0.789,2.578-0.789c1.13,0,2.019,0.305,2.664,0.914s0.969,1.367,0.969,2.273
+					c0,0.516-0.093,1.007-0.277,1.473s-0.478,0.954-0.879,1.465c-0.266,0.339-0.745,0.825-1.438,1.461s-1.132,1.058-1.316,1.266
+					s-0.335,0.411-0.449,0.609H123.161z"/>
+				<path fill="#FFFFFF" d="M128.356-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.429-2.695-1.285
+					s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C126.383-16.154,127.247-16.545,128.356-16.545z M128.356-14.724
+					c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91
+					c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77s-0.306-0.839-0.512-1.008S128.622-14.724,128.356-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M123.161-7.084v2.039h-7.695c0.083-0.771,0.333-1.501,0.75-2.191
+					s1.239-1.605,2.469-2.746c0.989-0.922,1.597-1.547,1.82-1.875c0.302-0.453,0.453-0.901,0.453-1.344
+					c0-0.489-0.132-0.866-0.395-1.129s-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.138-1.094,0.414s-0.427,0.734-0.469,1.375
+					l-2.188-0.219c0.13-1.208,0.539-2.075,1.227-2.602s1.547-0.789,2.578-0.789c1.13,0,2.019,0.305,2.664,0.914
+					s0.969,1.367,0.969,2.273c0,0.516-0.093,1.007-0.277,1.473s-0.478,0.954-0.879,1.465c-0.266,0.339-0.745,0.825-1.438,1.461
+					s-1.132,1.058-1.316,1.266s-0.335,0.411-0.449,0.609H123.161z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M128.356-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.429-2.695-1.285s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C126.383-16.154,127.247-16.545,128.356-16.545z M128.356-14.724c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91
+					c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25
+					s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77
+					s-0.306-0.839-0.512-1.008S128.622-14.724,128.356-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M147.56-8.084l2.125-0.258c0.067,0.542,0.25,0.956,0.547,1.242s0.656,0.43,1.078,0.43
+					c0.453,0,0.835-0.172,1.145-0.516s0.465-0.808,0.465-1.391c0-0.552-0.148-0.989-0.445-1.312s-0.659-0.484-1.086-0.484
+					c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789c0.594,0.016,1.047-0.113,1.359-0.387s0.469-0.637,0.469-1.09
+					c0-0.386-0.114-0.692-0.344-0.922s-0.534-0.344-0.914-0.344c-0.375,0-0.695,0.13-0.961,0.391s-0.427,0.641-0.484,1.141
+					l-2.023-0.344c0.141-0.692,0.353-1.246,0.637-1.66s0.68-0.739,1.188-0.977s1.077-0.355,1.707-0.355
+					c1.078,0,1.942,0.344,2.594,1.031c0.536,0.562,0.805,1.198,0.805,1.906c0,1.005-0.55,1.808-1.648,2.406
+					c0.656,0.141,1.181,0.456,1.574,0.945s0.59,1.081,0.59,1.773c0,1.005-0.367,1.862-1.102,2.57s-1.648,1.062-2.742,1.062
+					c-1.036,0-1.896-0.298-2.578-0.895S147.669-7.12,147.56-8.084z"/>
+				<path fill="#FFFFFF" d="M160.247-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.429-2.695-1.285
+					s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C158.273-16.154,159.138-16.545,160.247-16.545z M160.247-14.724
+					c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91
+					c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77s-0.306-0.839-0.512-1.008S160.513-14.724,160.247-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M147.56-8.084l2.125-0.258c0.067,0.542,0.25,0.956,0.547,1.242
+					s0.656,0.43,1.078,0.43c0.453,0,0.835-0.172,1.145-0.516s0.465-0.808,0.465-1.391c0-0.552-0.148-0.989-0.445-1.312
+					s-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789c0.594,0.016,1.047-0.113,1.359-0.387
+					s0.469-0.637,0.469-1.09c0-0.386-0.114-0.692-0.344-0.922s-0.534-0.344-0.914-0.344c-0.375,0-0.695,0.13-0.961,0.391
+					s-0.427,0.641-0.484,1.141l-2.023-0.344c0.141-0.692,0.353-1.246,0.637-1.66s0.68-0.739,1.188-0.977s1.077-0.355,1.707-0.355
+					c1.078,0,1.942,0.344,2.594,1.031c0.536,0.562,0.805,1.198,0.805,1.906c0,1.005-0.55,1.808-1.648,2.406
+					c0.656,0.141,1.181,0.456,1.574,0.945s0.59,1.081,0.59,1.773c0,1.005-0.367,1.862-1.102,2.57s-1.648,1.062-2.742,1.062
+					c-1.036,0-1.896-0.298-2.578-0.895S147.669-7.12,147.56-8.084z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M160.247-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.429-2.695-1.285s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C158.273-16.154,159.138-16.545,160.247-16.545z M160.247-14.724c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91
+					c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25
+					s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77
+					s-0.306-0.839-0.512-1.008S160.513-14.724,160.247-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M183.831-5.045v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266h1.422v1.93h-1.422v2.305H183.831z
+					 M183.831-9.279v-3.914l-2.633,3.914H183.831z"/>
+				<path fill="#FFFFFF" d="M192.136-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.429-2.695-1.285
+					s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C190.162-16.154,191.026-16.545,192.136-16.545z M192.136-14.724
+					c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91
+					c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77s-0.306-0.839-0.512-1.008S192.401-14.724,192.136-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M183.831-5.045v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266
+					h1.422v1.93h-1.422v2.305H183.831z M183.831-9.279v-3.914l-2.633,3.914H183.831z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M192.136-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.429-2.695-1.285s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C190.162-16.154,191.026-16.545,192.136-16.545z M192.136-14.724c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91
+					c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25
+					s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77
+					s-0.306-0.839-0.512-1.008S192.401-14.724,192.136-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M211.448-7.99l2.188-0.227c0.062,0.495,0.247,0.887,0.555,1.176s0.661,0.434,1.062,0.434
+					c0.458,0,0.847-0.187,1.164-0.559s0.477-0.934,0.477-1.684c0-0.703-0.157-1.23-0.473-1.582s-0.726-0.527-1.23-0.527
+					c-0.63,0-1.195,0.278-1.695,0.836l-1.781-0.258l1.125-5.961h5.805v2.055h-4.141l-0.344,1.945c0.489-0.245,0.989-0.367,1.5-0.367
+					c0.974,0,1.8,0.354,2.477,1.062s1.016,1.628,1.016,2.758c0,0.942-0.273,1.784-0.82,2.523c-0.745,1.011-1.778,1.516-3.102,1.516
+					c-1.058,0-1.919-0.284-2.586-0.852S211.578-7.032,211.448-7.99z"/>
+				<path fill="#FFFFFF" d="M224.026-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.114,0-2.013-0.429-2.695-1.285
+					s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C222.053-16.154,222.917-16.545,224.026-16.545z M224.026-14.724
+					c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91
+					c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77s-0.306-0.839-0.512-1.008S224.292-14.724,224.026-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M211.448-7.99l2.188-0.227c0.062,0.495,0.247,0.887,0.555,1.176
+					s0.661,0.434,1.062,0.434c0.458,0,0.847-0.187,1.164-0.559s0.477-0.934,0.477-1.684c0-0.703-0.157-1.23-0.473-1.582
+					s-0.726-0.527-1.23-0.527c-0.63,0-1.195,0.278-1.695,0.836l-1.781-0.258l1.125-5.961h5.805v2.055h-4.141l-0.344,1.945
+					c0.489-0.245,0.989-0.367,1.5-0.367c0.974,0,1.8,0.354,2.477,1.062s1.016,1.628,1.016,2.758c0,0.942-0.273,1.784-0.82,2.523
+					c-0.745,1.011-1.778,1.516-3.102,1.516c-1.058,0-1.919-0.284-2.586-0.852S211.578-7.032,211.448-7.99z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M224.026-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.114,0-2.013-0.429-2.695-1.285s-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C222.053-16.154,222.917-16.545,224.026-16.545z M224.026-14.724c-0.266,0-0.503,0.085-0.711,0.254s-0.37,0.473-0.484,0.91
+					c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77s0.306,0.837,0.512,1.004s0.441,0.25,0.707,0.25
+					s0.503-0.085,0.711-0.254s0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.067-2.267-0.203-2.77
+					s-0.306-0.839-0.512-1.008S224.292-14.724,224.026-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M247.612-5.045v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266h1.422v1.93h-1.422v2.305H247.612z
+					 M247.612-9.279v-3.914l-2.633,3.914H247.612z"/>
+				<path fill="#FFFFFF" d="M255.917-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.429-2.695-1.285
+					c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C253.943-16.154,254.808-16.545,255.917-16.545z
+					 M255.917-14.724c-0.266,0-0.503,0.085-0.711,0.254c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867
+					s0.067,2.267,0.203,2.77c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C256.418-14.639,256.183-14.724,255.917-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M247.612-5.045v-2.305h-4.688v-1.922l4.969-7.273h1.844v7.266
+					h1.422v1.93h-1.422v2.305H247.612z M247.612-9.279v-3.914l-2.633,3.914H247.612z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M255.917-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.429-2.695-1.285c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C253.943-16.154,254.808-16.545,255.917-16.545z M255.917-14.724c-0.266,0-0.503,0.085-0.711,0.254
+					c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C256.418-14.639,256.183-14.724,255.917-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M275.118-8.084l2.125-0.258c0.067,0.542,0.25,0.956,0.547,1.242s0.656,0.43,1.078,0.43
+					c0.453,0,0.834-0.172,1.145-0.516c0.31-0.344,0.465-0.808,0.465-1.391c0-0.552-0.148-0.989-0.445-1.312
+					s-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789c0.594,0.016,1.047-0.113,1.359-0.387
+					s0.469-0.637,0.469-1.09c0-0.386-0.115-0.692-0.344-0.922c-0.229-0.229-0.534-0.344-0.914-0.344
+					c-0.375,0-0.695,0.13-0.961,0.391s-0.427,0.641-0.484,1.141l-2.023-0.344c0.141-0.692,0.353-1.246,0.637-1.66
+					c0.284-0.414,0.68-0.739,1.188-0.977s1.077-0.355,1.707-0.355c1.078,0,1.942,0.344,2.594,1.031
+					c0.536,0.562,0.805,1.198,0.805,1.906c0,1.005-0.55,1.808-1.648,2.406c0.656,0.141,1.181,0.456,1.574,0.945
+					c0.393,0.489,0.59,1.081,0.59,1.773c0,1.005-0.367,1.862-1.102,2.57s-1.648,1.062-2.742,1.062c-1.037,0-1.896-0.298-2.578-0.895
+					C275.623-6.341,275.228-7.12,275.118-8.084z"/>
+				<path fill="#FFFFFF" d="M287.806-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.429-2.695-1.285
+					c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C285.832-16.154,286.696-16.545,287.806-16.545z
+					 M287.806-14.724c-0.266,0-0.503,0.085-0.711,0.254c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867
+					s0.067,2.267,0.203,2.77c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C288.307-14.639,288.071-14.724,287.806-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M275.118-8.084l2.125-0.258c0.067,0.542,0.25,0.956,0.547,1.242
+					s0.656,0.43,1.078,0.43c0.453,0,0.834-0.172,1.145-0.516c0.31-0.344,0.465-0.808,0.465-1.391c0-0.552-0.148-0.989-0.445-1.312
+					s-0.659-0.484-1.086-0.484c-0.281,0-0.617,0.055-1.008,0.164l0.242-1.789c0.594,0.016,1.047-0.113,1.359-0.387
+					s0.469-0.637,0.469-1.09c0-0.386-0.115-0.692-0.344-0.922c-0.229-0.229-0.534-0.344-0.914-0.344
+					c-0.375,0-0.695,0.13-0.961,0.391s-0.427,0.641-0.484,1.141l-2.023-0.344c0.141-0.692,0.353-1.246,0.637-1.66
+					c0.284-0.414,0.68-0.739,1.188-0.977s1.077-0.355,1.707-0.355c1.078,0,1.942,0.344,2.594,1.031
+					c0.536,0.562,0.805,1.198,0.805,1.906c0,1.005-0.55,1.808-1.648,2.406c0.656,0.141,1.181,0.456,1.574,0.945
+					c0.393,0.489,0.59,1.081,0.59,1.773c0,1.005-0.367,1.862-1.102,2.57s-1.648,1.062-2.742,1.062c-1.037,0-1.896-0.298-2.578-0.895
+					C275.623-6.341,275.228-7.12,275.118-8.084z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M287.806-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.429-2.695-1.285c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C285.832-16.154,286.696-16.545,287.806-16.545z M287.806-14.724c-0.266,0-0.503,0.085-0.711,0.254
+					c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C288.307-14.639,288.071-14.724,287.806-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M314.501-7.084v2.039h-7.695c0.083-0.771,0.333-1.501,0.75-2.191c0.417-0.69,1.239-1.605,2.469-2.746
+					c0.989-0.922,1.596-1.547,1.82-1.875c0.302-0.453,0.453-0.901,0.453-1.344c0-0.489-0.132-0.866-0.395-1.129
+					c-0.263-0.263-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.138-1.094,0.414c-0.271,0.276-0.427,0.734-0.469,1.375l-2.188-0.219
+					c0.13-1.208,0.539-2.075,1.227-2.602s1.547-0.789,2.578-0.789c1.13,0,2.018,0.305,2.664,0.914
+					c0.646,0.609,0.969,1.367,0.969,2.273c0,0.516-0.093,1.007-0.277,1.473c-0.185,0.466-0.478,0.954-0.879,1.465
+					c-0.266,0.339-0.745,0.825-1.438,1.461c-0.693,0.636-1.132,1.058-1.316,1.266c-0.185,0.208-0.335,0.411-0.449,0.609H314.501z"/>
+				<path fill="#FFFFFF" d="M319.696-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.429-2.695-1.285
+					c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C317.722-16.154,318.587-16.545,319.696-16.545z
+					 M319.696-14.724c-0.266,0-0.503,0.085-0.711,0.254c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867
+					s0.067,2.267,0.203,2.77c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C320.197-14.639,319.962-14.724,319.696-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M314.501-7.084v2.039h-7.695c0.083-0.771,0.333-1.501,0.75-2.191
+					c0.417-0.69,1.239-1.605,2.469-2.746c0.989-0.922,1.596-1.547,1.82-1.875c0.302-0.453,0.453-0.901,0.453-1.344
+					c0-0.489-0.132-0.866-0.395-1.129c-0.263-0.263-0.626-0.395-1.09-0.395c-0.458,0-0.823,0.138-1.094,0.414
+					c-0.271,0.276-0.427,0.734-0.469,1.375l-2.188-0.219c0.13-1.208,0.539-2.075,1.227-2.602s1.547-0.789,2.578-0.789
+					c1.13,0,2.018,0.305,2.664,0.914c0.646,0.609,0.969,1.367,0.969,2.273c0,0.516-0.093,1.007-0.277,1.473
+					c-0.185,0.466-0.478,0.954-0.879,1.465c-0.266,0.339-0.745,0.825-1.438,1.461c-0.693,0.636-1.132,1.058-1.316,1.266
+					c-0.185,0.208-0.335,0.411-0.449,0.609H314.501z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M319.696-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.429-2.695-1.285c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C317.722-16.154,318.587-16.545,319.696-16.545z M319.696-14.724c-0.266,0-0.503,0.085-0.711,0.254
+					c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C320.197-14.639,319.962-14.724,319.696-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="#FFFFFF" d="M344.593-5.045h-2.195v-8.273c-0.802,0.75-1.748,1.305-2.836,1.664v-1.992
+					c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.134,1.383-1.832h1.781V-5.045z"/>
+				<path fill="#FFFFFF" d="M351.585-16.545c1.109,0,1.977,0.396,2.602,1.188c0.745,0.938,1.117,2.492,1.117,4.664
+					c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172c-1.115,0-2.013-0.429-2.695-1.285
+					c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656C349.611-16.154,350.476-16.545,351.585-16.545z
+					 M351.585-14.724c-0.266,0-0.503,0.085-0.711,0.254c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867
+					s0.067,2.267,0.203,2.77c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C352.086-14.639,351.851-14.724,351.585-14.724z"/>
+			</g>
+			<g enable-background="new    ">
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M344.593-5.045h-2.195v-8.273c-0.802,0.75-1.748,1.305-2.836,1.664
+					v-1.992c0.573-0.188,1.195-0.543,1.867-1.066s1.133-1.134,1.383-1.832h1.781V-5.045z"/>
+				<path fill="none" stroke="#808080" stroke-width="0.1772" d="M351.585-16.545c1.109,0,1.977,0.396,2.602,1.188
+					c0.745,0.938,1.117,2.492,1.117,4.664c0,2.167-0.375,3.724-1.125,4.672c-0.62,0.781-1.484,1.172-2.594,1.172
+					c-1.115,0-2.013-0.429-2.695-1.285c-0.683-0.856-1.023-2.384-1.023-4.582c0-2.156,0.375-3.708,1.125-4.656
+					C349.611-16.154,350.476-16.545,351.585-16.545z M351.585-14.724c-0.266,0-0.503,0.085-0.711,0.254
+					c-0.208,0.169-0.37,0.473-0.484,0.91c-0.151,0.567-0.227,1.523-0.227,2.867s0.067,2.267,0.203,2.77
+					c0.135,0.503,0.306,0.837,0.512,1.004c0.206,0.167,0.441,0.25,0.707,0.25s0.502-0.085,0.711-0.254
+					c0.208-0.169,0.37-0.473,0.484-0.91c0.151-0.562,0.227-1.516,0.227-2.859s-0.068-2.267-0.203-2.77
+					c-0.136-0.503-0.306-0.839-0.512-1.008C352.086-14.639,351.851-14.724,351.585-14.724z"/>
+			</g>
+			<g id="g4648">
+				
+					<path id="path4650" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M77.86-11.002l3.979-1.148v2.297L77.86-11.002z"/>
+				
+					<path id="path4652" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M109.749-11.002l3.978-1.148v2.297L109.749-11.002z"/>
+				
+					<path id="path4654" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M141.639-11.002l3.978-1.148v2.297L141.639-11.002z"/>
+				
+					<path id="path4656" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M173.528-11.002l3.979-1.148v2.297L173.528-11.002z"/>
+			</g>
+			<g id="g4658" transform="matrix(-1,0,0,1,383.739,0)">
+				
+					<path id="path4660" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M20.483-11.002l3.978-1.148v2.297L20.483-11.002z"/>
+				
+					<path id="path4662" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M52.372-11.002l3.978-1.148v2.297L52.372-11.002z"/>
+				
+					<path id="path4664" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M84.261-11.002l3.978-1.148v2.297L84.261-11.002z"/>
+				
+					<path id="path4666" sodipodi:r2="1.3260038" inkscape:randomized="0" sodipodi:arg1="3.1415927" sodipodi:arg2="4.1887902" sodipodi:r1="2.6520076" inkscape:rounded="0" inkscape:flatsided="true" sodipodi:cx="51.26923" sodipodi:cy="145.96883" sodipodi:sides="3" sodipodi:type="star" fill="#FFFFFF" d="
+					M116.151-11.002l3.978-1.148v2.297L116.151-11.002z"/>
+			</g>
+		</g>
+	</g>
+</g>
+</svg>

--- a/mapnik/symbols-otm/sports-rugby.svg
+++ b/mapnik/symbols-otm/sports-rugby.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 14.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 43363)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="800px" height="600px" viewBox="0 0 800 600" enable-background="new 0 0 800 600" xml:space="preserve">
+<rect x="60.5" y="-220.833" fill="none" stroke="#FFFFFF" width="200" height="140"/>
+<rect x="20.5" y="-220.833" fill="none" stroke="#FFFFFF" width="40" height="140"/>
+<rect x="260.5" y="-220.833" fill="none" stroke="#FFFFFF" width="40" height="140"/>
+<line fill="none" stroke="#FFFFFF" x1="216.5" y1="-220.833" x2="216.5" y2="-80.833"/>
+<line fill="none" stroke="#FFFFFF" x1="104.5" y1="-220.833" x2="104.5" y2="-80.833"/>
+<line fill="none" stroke="#FFFFFF" x1="160.5" y1="-220.833" x2="160.5" y2="-80.833"/>
+<line fill="none" stroke="#FFFFFF" x1="180.5" y1="-220.833" x2="180.5" y2="-80.833"/>
+<line fill="none" stroke="#FFFFFF" x1="140.5" y1="-220.833" x2="140.5" y2="-80.833"/>
+<line fill="none" stroke="#FFFFFF" x1="60.5" y1="-90.833" x2="260.5" y2="-90.833"/>
+<line fill="none" stroke="#FFFFFF" x1="60.5" y1="-210.833" x2="260.5" y2="-210.833"/>
+<line fill="none" stroke="#FFFFFF" x1="60.5" y1="-160.77" x2="51.103" y2="-164.19"/>
+<line fill="none" stroke="#FFFFFF" x1="60.5" y1="-140.77" x2="51.103" y2="-137.35"/>
+<line fill="none" stroke="#FFFFFF" x1="55.802" y1="-162.77" x2="55.802" y2="-139.06"/>
+<line fill="none" stroke="#FFFFFF" x1="260.5" y1="-160.77" x2="269.897" y2="-164.19"/>
+<line fill="none" stroke="#FFFFFF" x1="260.5" y1="-140.77" x2="269.897" y2="-137.35"/>
+<line fill="none" stroke="#FFFFFF" x1="265.199" y1="-162.48" x2="265.198" y2="-139.06"/>
+</svg>

--- a/mapnik/symbols-otm/sports-soccer.svg
+++ b/mapnik/symbols-otm/sports-soccer.svg
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 12.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 51448)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   width="444.196"
+   height="260.538"
+   viewBox="0 0 444.196 260.538"
+   overflow="visible"
+   enable-background="new 0 0 444.196 260.538"
+   xml:space="preserve"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="Foot_field_AG3.svg"><metadata
+   id="metadata229"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs227" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1804"
+   inkscape:window-height="1206"
+   id="namedview225"
+   showgrid="false"
+   inkscape:zoom="2"
+   inkscape:cx="222.09801"
+   inkscape:cy="90.268997"
+   inkscape:window-x="2954"
+   inkscape:window-y="165"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="Layer_1" />
+
+<line
+   fill="none"
+   x1="37.919"
+   y1="19.892"
+   x2="37.619"
+   y2="256.337"
+   id="line5" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="37.128"
+   y1="19.892"
+   x2="391.986"
+   y2="19.892"
+   id="line7" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="391.986"
+   y1="18.94"
+   x2="391.986"
+   y2="257.113"
+   id="line9" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="391.986"
+   y1="256.037"
+   x2="37.619"
+   y2="256.337"
+   id="line11" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="37.919"
+   y1="53.198"
+   x2="107.832"
+   y2="52.898"
+   id="line13" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="107.832"
+   y1="52.156"
+   x2="108.432"
+   y2="224.407"
+   id="line15" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="108.432"
+   y1="223.331"
+   x2="37.919"
+   y2="223.331"
+   id="line17" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="37.619"
+   y1="176.822"
+   x2="61.323"
+   y2="176.522"
+   id="line19" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="37.919"
+   y1="99.707"
+   x2="61.323"
+   y2="99.407"
+   id="line21" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="61.323"
+   y1="98.579"
+   x2="61.323"
+   y2="177.671"
+   id="line23" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="37.619"
+   y1="123.112"
+   x2="26.883"
+   y2="123.112"
+   id="line25" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="27.717"
+   y1="123.112"
+   x2="27.717"
+   y2="154.018"
+   id="line27" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="27.078"
+   y1="154.018"
+   x2="37.319"
+   y2="154.317"
+   id="line29" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="214.953"
+   y1="19.892"
+   x2="215.252"
+   y2="256.937"
+   id="line31" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="321.003"
+   y1="53.198"
+   x2="391.986"
+   y2="53.198"
+   id="line33" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="322.073"
+   y1="53.198"
+   x2="322.673"
+   y2="223.331"
+   id="line35" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="321.707"
+   y1="223.331"
+   x2="391.686"
+   y2="223.331"
+   id="line37" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="367.861"
+   y1="99.707"
+   x2="391.986"
+   y2="99.707"
+   id="line39" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="368.882"
+   y1="99.707"
+   x2="369.481"
+   y2="177.879"
+   id="line41" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="369.481"
+   y1="176.822"
+   x2="391.986"
+   y2="176.822"
+   id="line43" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="392.286"
+   y1="122.512"
+   x2="402.488"
+   y2="122.512"
+   id="line45" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="402.488"
+   y1="121.543"
+   x2="402.488"
+   y2="155.203"
+   id="line47" />
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="402.49"
+   y1="154.182"
+   x2="392.284"
+   y2="154.152"
+   id="line49" />
+<ellipse
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   cx="215.403"
+   cy="138.715"
+   rx="40.358"
+   ry="38.407"
+   id="ellipse51" />
+<circle
+   fill="#FFFFFF"
+   cx="215.183"
+   cy="138.714"
+   r="2.7"
+   id="circle53" />
+<circle
+   fill="#FFFFFF"
+   cx="345.777"
+   cy="138.414"
+   r="2.7"
+   id="circle55" />
+<circle
+   fill="#FFFFFF"
+   cx="84.826"
+   cy="138.116"
+   r="2.7"
+   id="circle57" />
+<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   d="M107.606,108.297c9.95,6.755,16.429,17.773,16.429,30.217  c0,12.319-6.349,23.239-16.129,30.011"
+   id="path59" />
+<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   d="M321.851,108.216c-9.791,6.983-16.012,18.149-15.724,30.59  c0.286,12.315,6.886,23.085,16.821,29.628"
+   id="path61" />
+<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   d="M44.876,19.881c0.094,0.438,0.144,0.894,0.144,1.361  c0,3.397-2.62,6.151-5.851,6.151c-0.443,0-0.874-0.052-1.289-0.15"
+   id="path63" />
+<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   d="M392.106,27.475c-0.445,0.053-0.902,0.061-1.369,0.018  c-3.383-0.313-5.883-3.175-5.584-6.393c0.041-0.441,0.131-0.866,0.268-1.27"
+   id="path65" />
+<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   d="M384.896,256.052c-0.051-0.445-0.054-0.903-0.007-1.369  c0.343-3.38,3.226-5.855,6.44-5.53c0.441,0.045,0.865,0.141,1.268,0.279"
+   id="path67" />
+<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="1.5"
+   d="M38.048,248.943c0.444-0.059,0.902-0.072,1.369-0.034  c3.387,0.274,5.92,3.107,5.659,6.328c-0.035,0.441-0.121,0.867-0.253,1.272"
+   id="path69" />
+
+
+
+
+
+<line
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="2"
+   x1="37.94"
+   y1="19.777"
+   x2="38.24"
+   y2="256.822"
+   id="line99" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</svg>

--- a/mapnik/symbols-otm/sports-tennis.svg
+++ b/mapnik/symbols-otm/sports-tennis.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="sports-tennis.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="123.52509"
+     inkscape:cy="120.11736"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1674"
+     inkscape:window-height="1313"
+     inkscape:window-x="2560"
+     inkscape:window-y="22"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       id="rect2985"
+       width="240"
+       height="110"
+       x="0"
+       y="942.36218" />
+    <path
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       d="m 120.90005,1051.0481 0,-109.07292 0,0"
+       id="path4115"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       d="m 0,1038.8622 240,0"
+       id="path4117"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       d="m 0,955.86218 240,1"
+       id="path4119"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       d="m 55,955.86218 0,83.00002"
+       id="path4123"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       d="m 184,956.86218 0,82.00002"
+       id="path4125"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke:#fff;stroke-opacity:1"
+       d="m 184,997.36218 -129,0"
+       id="path4127"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/mapnik/tools/pitchicon.sql
+++ b/mapnik/tools/pitchicon.sql
@@ -1,0 +1,123 @@
+-- FUNCTION getpitchicon(inway IN GEOMETRY,sport IN TEXT) RETURNS otm_pitch
+-- 
+-- Gets a geometry (a way in EPSG:3857) of a pitch, and a sport=*, calculates the
+-- size and the direction of a label and returns a composite type with
+--
+--  icon            text:  something like 'soccer', 'tennis' derived from sport
+--  pitch_area      float: area of the pitch im m^2
+--  angle           float: rotation of the pitch (0°=North) 
+--  labelsizefactor float: a factor to strech the icon, depends on the latitude
+--
+--  derived from https://github.com/giggls/openstreetmap-carto-de, which was
+--  derived from https://github.com/cquest/osmfr-cartocss. Thanks.
+
+--
+-- a composite type to return the 4 values
+--
+CREATE TYPE otm_pitch AS (icon TEXT,pitch_area FLOAT,angle FLOAT,labelsizefactor FLOAT);
+
+--
+-- the function
+--
+CREATE OR REPLACE FUNCTION getpitchicon(inway IN GEOMETRY,sport IN TEXT) RETURNS otm_pitch AS $$
+
+ DECLARE
+  way             GEOMETRY;
+  d12             FLOAT;
+  d23             FLOAT;
+  d13             FLOAT;
+  a12             FLOAT;
+  a23             FLOAT;
+  labelsizefactor FLOAT;
+  angle           FLOAT;
+  angle_diff      FLOAT;
+  pitch_area      FLOAT;
+  n1              GEOMETRY;
+  n2              GEOMETRY;
+  n3              GEOMETRY;
+  sportlist       TEXT;
+  icon            TEXT;
+  ret             otm_pitch;
+
+ BEGIN
+  ret.icon=NULL;
+  sportlist=';'||sport||';';
+--
+-- first we check, that its a kind of sport, we have a icon for. If not we don't have to calculate
+--
+  IF((sportlist like '%;tennis;%')            OR (sportlist like '%;soccer;%')      OR (sportlist like '%;basketball;%')    OR
+     (sportlist like '%;rugby;%')             OR (sportlist like '%;rugby_union;%') OR (sportlist like '%;rugby_league;%')  OR 
+     (sportlist like '%;american_football;%') ) THEN
+--
+-- get a simplified rectangle around the way, get the first 3 corners of this rectangle
+--
+   way=ST_ExteriorRing(ST_SimplifyPreserveTopology((st_dump(inway)).geom,100));
+   n1:=ST_Transform(ST_PointN(way,1),4326);
+   n2:=ST_Transform(ST_PointN(way,2),4326);
+   n3:=ST_Transform(ST_PointN(way,3),4326);
+--
+-- calculate length of the first 2 sides (d12,d23), the diagonal (d13),
+-- the angle between the sides and one angle to the north direction of d12 or d23
+--
+   d12:=ST_DistanceSphere(n1,n2);
+   d23:=ST_DistanceSphere(n2,n3);
+   d13:=ST_DistanceSphere(n1,n3);
+   pitch_area:=d12*d23;
+   a12:=degrees(ST_Azimuth(ST_PointN(way,1),ST_PointN(way,2)));
+   a23:=degrees(ST_Azimuth(ST_PointN(way,2),ST_PointN(way,3)));
+   angle_diff:=cast(abs(a12-a23) as integer)%180;
+   angle:=(a12+a23+90)/2;
+--
+-- we need a correction factor, because we calculate all distances with ST_DistanceSphere() in m and have maps and icons in 3857
+--
+   labelsizefactor:=1/(cos(ST_Y(n2)/180*3.1415927));
+   icon:=NULL;
+--
+-- we need something like a rectangle with corners near 90°
+--
+   IF ((angle_diff>85) AND (angle_diff<95)) THEN
+--
+-- check if we got a real tennis pitch:
+-- a tennis court is <1100 ^2, and its diagonal ist 20-43m, one side is 20-45m and the other side is 8-30m
+-- 
+    IF (sportlist like '%;tennis;%') THEN
+     IF((pitch_area<1100) AND (d13>20) AND (d13<52) ) THEN 
+      IF ((d12>20) AND (d12<45) AND (d23>8) AND (d23<30)) THEN icon:='tennis';                END IF; 
+      IF ((d23>20) AND (d23<45) AND (d12>8) AND (d12<30)) THEN icon:='tennis';angle:=angle+90;END IF;
+     END IF;
+--
+-- similar checks for other sports (for soccer pitch_area hast to be checked in the style) 
+--    
+    ELSIF (sportlist like '%;soccer;%') THEN
+     IF ((d12>90) AND (d12<130) AND (d23>45) AND (d23<110) AND (d13>100) AND (d13<170)) THEN icon:='soccer';                END IF;
+     IF ((d23>80) AND (d23<130) AND (d12>45) AND (d12<110) AND (d13>100) AND (d13<170)) THEN icon:='soccer';angle:=angle+90;END IF;
+    ELSIF (sportlist like '%;basketball;%') THEN
+     IF ((pitch_area<450) AND (d13>20) AND (d13<35) ) THEN
+      IF ((d12>20) AND (d12<30) AND (d23>10) AND (d23<20)) THEN icon:='bascetball';                END IF;
+      IF ((d23>20) AND (d23<30) AND (d12>10) AND (d12<20)) THEN icon:='bascetball';angle:=angle+90;END IF;
+     END IF;
+    ELSIF (sportlist like '%rugby%') THEN
+     IF ((pitch_area>6000) AND (pitch_area<11000) AND (d13>100) AND (d13<170)) THEN
+      IF ((d23>50) AND (d23<100) AND (d12>100) AND (d12<170)) THEN icon:='rugby';                END IF;
+      IF ((d12>50) AND (d12<100) AND (d23>100) AND (d23<170)) THEN icon:='rugby';angle:=angle+90;END IF;
+     END IF;
+    ELSIF (sportlist like '%;american_football;%') THEN
+     IF ((pitch_area>3500) AND (pitch_area<8500) AND (d13>80) AND (d13<170)) THEN
+      IF ((d23>32) AND (d23<65) AND (d12>80) AND (d12<130)) THEN icon:='football';                END IF; 
+      IF ((d12>32) AND (d12<65) AND (d23>80) AND (d23<130)) THEN icon:='football';angle:=angle+90;END IF;
+     END IF;
+    END IF;
+   END IF;
+   if (icon IS NOT NULL) THEN
+    ret.icon:=icon;
+    ret.angle:=angle;
+    ret.pitch_area:=pitch_area;
+    ret.labelsizefactor:=labelsizefactor;
+   END IF;
+  ELSE 
+   ret.icon:=NULL;
+  END IF;  
+  return ret;
+ END;
+$$ LANGUAGE plpgsql;
+

--- a/mapnik/tools/pitchicon.sql
+++ b/mapnik/tools/pitchicon.sql
@@ -66,7 +66,7 @@ CREATE OR REPLACE FUNCTION getpitchicon(inway IN GEOMETRY,sport IN TEXT) RETURNS
    a12:=degrees(ST_Azimuth(ST_PointN(way,1),ST_PointN(way,2)));
    a23:=degrees(ST_Azimuth(ST_PointN(way,2),ST_PointN(way,3)));
    angle_diff:=cast(abs(a12-a23) as integer)%180;
-   angle:=(a12+a23+90)/2;
+   angle:=90+(a12+a23+90)/2;
 --
 -- we need a correction factor, because we calculate all distances with ST_DistanceSphere() in m and have maps and icons in 3857
 --
@@ -85,23 +85,27 @@ CREATE OR REPLACE FUNCTION getpitchicon(inway IN GEOMETRY,sport IN TEXT) RETURNS
       IF ((d12>20) AND (d12<45) AND (d23>8) AND (d23<30)) THEN icon:='tennis';                END IF; 
       IF ((d23>20) AND (d23<45) AND (d12>8) AND (d12<30)) THEN icon:='tennis';angle:=angle+90;END IF;
      END IF;
+    END IF;
 --
 -- similar checks for other sports (for soccer pitch_area hast to be checked in the style) 
 --    
-    ELSIF (sportlist like '%;soccer;%') THEN
+    IF ((icon IS NULL) AND (sportlist like '%;soccer;%')) THEN
      IF ((d12>90) AND (d12<130) AND (d23>45) AND (d23<110) AND (d13>100) AND (d13<170)) THEN icon:='soccer';                END IF;
      IF ((d23>80) AND (d23<130) AND (d12>45) AND (d12<110) AND (d13>100) AND (d13<170)) THEN icon:='soccer';angle:=angle+90;END IF;
-    ELSIF (sportlist like '%;basketball;%') THEN
+    END IF;
+    IF ((icon IS NULL) AND (sportlist like '%;basketball;%')) THEN
      IF ((pitch_area<450) AND (d13>20) AND (d13<35) ) THEN
-      IF ((d12>20) AND (d12<30) AND (d23>10) AND (d23<20)) THEN icon:='bascetball';                END IF;
-      IF ((d23>20) AND (d23<30) AND (d12>10) AND (d12<20)) THEN icon:='bascetball';angle:=angle+90;END IF;
+      IF ((d12>20) AND (d12<30) AND (d23>10) AND (d23<20)) THEN icon:='basketball';                END IF;
+      IF ((d23>20) AND (d23<30) AND (d12>10) AND (d12<20)) THEN icon:='basketball';angle:=angle+90;END IF;
      END IF;
-    ELSIF (sportlist like '%rugby%') THEN
+    END IF;
+    IF ((icon IS NULL) AND (sportlist like '%rugby%')) THEN
      IF ((pitch_area>6000) AND (pitch_area<11000) AND (d13>100) AND (d13<170)) THEN
       IF ((d23>50) AND (d23<100) AND (d12>100) AND (d12<170)) THEN icon:='rugby';                END IF;
       IF ((d12>50) AND (d12<100) AND (d23>100) AND (d23<170)) THEN icon:='rugby';angle:=angle+90;END IF;
      END IF;
-    ELSIF (sportlist like '%;american_football;%') THEN
+    END IF;
+    IF ((icon IS NULL) AND (sportlist like '%;american_football;%')) THEN
      IF ((pitch_area>3500) AND (pitch_area<8500) AND (d13>80) AND (d13<170)) THEN
       IF ((d23>32) AND (d23<65) AND (d12>80) AND (d12<130)) THEN icon:='football';                END IF; 
       IF ((d12>32) AND (d12<65) AND (d23>80) AND (d23<130)) THEN icon:='football';angle:=angle+90;END IF;


### PR DESCRIPTION
Patch for #11 to render yard lines on pitches:

![yard lines](https://geo.dianacht.de/bilder/otm_soccer_1.png)

I took the code and the symbols of the french and german style. Thanks to @cquest and @giggls.

Differences to the the german style:
* openstreetmap.de uses surface=* to color the pitches (red for surface=clay). I think that's too colorful for this style, so all is green...
* we don't care of access=private at tennis courts
* Some pitches have sport='soccer;ice_skating'. In this cases we take this sport, we have an icon for (in this case soccer)

Diference to official topographic maps: Official maps use some kind of ellipses for some(?) pitches ([example](https://geoportal.bayern.de/bayernatlas/index.html?X=5338137.50&Y=4466078.53&zoom=12&lang=de&topic=zeitr&bgLayer=atkis&layers_timestamp=20071231&layers=zeitreihe_tk&time=2007)) and use different ellipses for pitches with/without surrounding running tracks. I prefer the french style, because it's more clear (I didn't find the difference between squares and ellipses in the example above) and in OSM we can't see at the pitch whether there is a track around it.

Things we may have to adjust:
* pitches with markers get an additional green background with 80% opacity to get some contrast to the white lines. pitches without don't. We have to see, whether its too dark or too light and maybe we should color all pitches darker.
* there are a lot of restrictions what a "real" pitch is (e.g. a soccer field is (90-130)X(45-110) and its diagonal is 100-170m). We will find a lot of pitches witch are not rendered. On the other hand it was a lot of work to adjust these restrictions for the other styles, we won't find better ones ;)

