### PR TITLE
exclude towers from viewpoints

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -586,7 +586,7 @@
 	<Layer name="symbols-viewpoint">
 		<StyleName>symbols-viewpoint</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,tourism,(int_dir).s1 as firstrotation,(int_dir).a1 as firstangle,(int_dir).s2 as secondrotation,(int_dir).a2 as secondangle FROM (SELECT way,tourism,viewpointdirection(direction) AS int_dir FROM planet_osm_point WHERE tourism='viewpoint') AS viewpoints) AS symbols</Parameter>
+			<Parameter name="table">(SELECT way,tourism,(int_dir).s1 as firstrotation,(int_dir).a1 as firstangle,(int_dir).s2 as secondrotation,(int_dir).a2 as secondangle FROM (SELECT way,tourism,viewpointdirection(direction) AS int_dir FROM planet_osm_point WHERE tourism='viewpoint' AND man_made!='tower') AS viewpoints) AS symbols</Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>


### PR DESCRIPTION
We already have a rule for (man_made=tower and (tower:type=observation or tourism=viewpoint)) in symbols-2.xml and an icon for observation towers. 
We should exclude towers from the rules for rotated viewpoints to avoid mixing these icons like at [this point](https://opentopomap.org/#map=17/50.83109/13.65792). We will loose the information about direction at these towers, but a clear sign for "observation tower" seems more interesting than the direction.
([discussion in the german forum](https://forum.openstreetmap.org/viewtopic.php?pid=654135#p654135))

This also affects some towers which are not observation towers (e.g [this historic=castle, tower:type=defensive](https://opentopomap.org/#map=17/49.42246/12.61675) (node 1872843531), but also here I think it's better to have a clear icon for the castle.
