### PR TITLE
sport=multi, sport=basketball

### DIFF
--- a/mapnik/styles-otm/symbols-sport.xml
+++ b/mapnik/styles-otm/symbols-sport.xml
@@ -3,13 +3,13 @@
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
-		<Filter>([icon]='soccer' and [pitch_area] &gt; 3500)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer-oval_z13.svg" transform="rotate([angle]) scale(0.19*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
-		<Filter>([icon]='soccer' and [pitch_area] &gt; 3500)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-soccer-oval_z14.svg" transform="rotate([angle]) scale(0.31*[labelsizefactor])"/>
 	</Rule>
 	
@@ -114,5 +114,18 @@
 		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-foot-us.svg" transform="rotate([angle]) scale(0.207*[labelsizefactor])"/>
 	</Rule>
 
+	<!-- no icon -->
+	<Rule>
+		&maxscale_zoom16;
+		&minscale_zoom16;
+		<Filter>([icon]='multi' or [icon]=null)</Filter>
+		<PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+	</Rule>
+	<Rule>
+		&maxscale_zoom17;
+		&minscale_zoom17;
+		<Filter>([icon]='multi' or [icon]=null)</Filter>
+		<PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
+	</Rule>
 </Style>
 

--- a/mapnik/styles-otm/symbols-sport.xml
+++ b/mapnik/styles-otm/symbols-sport.xml
@@ -114,11 +114,11 @@
 		<PointSymbolizer allow-overlap="yes" file="symbols-otm/sports-foot-us.svg" transform="rotate([angle]) scale(0.207*[labelsizefactor])"/>
 	</Rule>
 
-	<!-- no icon -->
+	<!-- no icon but colored pitches -->
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom16;
-		<Filter>([icon]='multi' or [icon]=null)</Filter>
+		<Filter>([icon]='multi' or [icon]='basketball' or [icon]=null)</Filter>
 		<PolygonSymbolizer fill="#b6dea4" fill-opacity="0.8" />
 	</Rule>
 	<Rule>

--- a/mapnik/tools/pitchicon.sql
+++ b/mapnik/tools/pitchicon.sql
@@ -106,8 +106,6 @@ CREATE OR REPLACE FUNCTION getpitchicon(inway geometry, sport text) RETURNS otm_
       IF ((d12>20) AND (d12<35) AND (d23>10) AND (d23<35)) THEN icon:='basketball';                END IF;
       IF ((d23>20) AND (d23<35) AND (d12>10) AND (d12<35)) THEN icon:='basketball';angle:=angle+90;END IF;
      END IF;
-     IF (icon IS NULL) THEN raise notice 'Basketball neg id % d12 % d23 % d13 % pa %',0,d12,d23,d13,pitch_area; 
-     else                   raise notice 'Basketball pos id % d12 % d23 % d13 % pa %',0,d12,d23,d13,pitch_area; END IF;
     END IF;
     IF ((icon IS NULL) AND (sportlist like '%rugby%')) THEN
      IF ((pitch_area>6000) AND (pitch_area<11000) AND (d13>100) AND (d13<170)) THEN


### PR DESCRIPTION
See #11 

* render sport=multi samre as sport=soccer in z=13-14
* allow larger basketball pitches
* render pitches without sport=* (or sport=x where we have no icon) in same color as other pitches 

**Maybe todo**: Adjust color for all/some the pitches in symbols-sport.xml. now all are rendered with fill="#b6dea4" fill-opacity="0.8".

![soccer No3](http://geo.dianacht.de/bilder/otm_soccer3.png)
[Sportschule Oberhaching](http://www.openstreetmap.org/#map=16/48.0368/11.5901)
