### PR TITLE
less peaks in mid zoom levels, but enforce their rendering

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -617,7 +617,7 @@
 	<Layer name="symbols-point-midzoom">
 		<StyleName>symbols-point-midzoom</StyleName>
 		<Datasource>
-			<Parameter name="table">(SELECT way,access,amenity,highway,historic,"memorial:type",castle_type,leaf_type,religion,denomination,denotation,"man_made","tower:type","communication:radio","communication:television",building,"natural",name,ruins,"summit:cross",tourism,"power","generator:source","site_type",sport,disused,abandoned,railway,train,subway,otm_isolation::INTEGER FROM planet_osm_point WHERE "natural"='peak' OR "natural"='volcano') AS symbols </Parameter>
+			<Parameter name="table">(SELECT way,access,amenity,highway,historic,"memorial:type",castle_type,leaf_type,religion,denomination,denotation,"man_made","tower:type","communication:radio","communication:television",building,"natural",name,ruins,"summit:cross",tourism,"power","generator:source","site_type",sport,disused,abandoned,railway,train,subway,otm_isolation::INTEGER FROM planet_osm_point WHERE "natural"='peak' OR "natural"='volcano' ORDER BY otm_isolation::INTEGER DESC) AS symbols </Parameter>
 			<Parameter name="dbname">gis</Parameter>
 			&postgis-settings;
 		</Datasource>

--- a/mapnik/styles-otm/text-natural-point-midzoom.xml
+++ b/mapnik/styles-otm/text-natural-point-midzoom.xml
@@ -3,14 +3,14 @@
 		&maxscale_zoom10;
 		&minscale_zoom10;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and (not ([name] = null)) and ([otm_isolation] &gt; 16000)</Filter>
-		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="3" wrap-width="100">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="3" wrap-width="100">[name]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom11;
 		&minscale_zoom11;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and (not ([name] = null)) and ([otm_isolation] &gt; 6000)</Filter>
-		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="3" wrap-width="100">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="3" wrap-width="100">[name]</TextSymbolizer>
 	</Rule>
 
 
@@ -18,13 +18,13 @@
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and ([name] = null) and ([otm_isolation] &gt; 1200)</Filter>
-		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="3" wrap-width="100">[ele]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="3" wrap-width="100">[ele]</TextSymbolizer>
 	</Rule>
 
 	<Rule>
 		&maxscale_zoom12;
 		&minscale_zoom12;
 		<Filter>([natural] = 'peak' or [natural] = 'volcano') and (not ([name] = null)) and ([otm_isolation] &gt; 1200)</Filter>
-		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" dy="3" wrap-width="100">[name]</TextSymbolizer>
+		<TextSymbolizer fontset-name="sans-oblique" size="9" fill="black" margin="1" halo-radius="2" halo-fill="rgba(255,255,255,0.8)" placement="point" allow-overlap="true" dy="3" wrap-width="100">[name]</TextSymbolizer>
 	</Rule>
 </Style>


### PR DESCRIPTION
When zooming in from Z10 to Z11 or Z12 a lot og peaks disappear. Their label collides with the labels of our contour line. 
For example here: https://opentopomap.org/#map=11/47.5809/11.4450 the "Benediktenwand" is labeled in Z11 but not in Z12. Or here: https://opentopomap.org/#map=10/46.5301/10.5853 "Ortler-Ortles" is visible in Z10 and not Z11.

I would suggest to enforce labeling with allow-overlap="true" and to reduce the number of labels by increasing the isolation for mid zoom levels.
