### PR TITLE
Tracks arround soccer fields

### DIFF
--- a/mapnik/styles-otm/symbols-sport.xml
+++ b/mapnik/styles-otm/symbols-sport.xml
@@ -1,29 +1,27 @@
 <Style name="symbols-sport">
 	<!-- sports ovals at zoom 13-14 -->
-	<!--<Rule>
+	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
-		<Filter>((([icon]='soccer' or [icon]='multi') and [athletics_track] = 'yes') and [pitch_area] &gt; 3500)</Filter>
+		<Filter>(([icon]='soccer_with_track' or [icon]='multi_with_track') and [pitch_area] &gt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-oval-track_z13.svg" transform="rotate([angle]) scale(0.19*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
-		<Filter>((([icon]='soccer' or [icon]='multi') and [athletics_track] = 'yes') and [pitch_area] &gt; 3500)</Filter>
+		<Filter>(([icon]='soccer_with_track' or [icon]='multi_with_track') and [pitch_area] &gt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-oval-track_z14.svg" transform="rotate([angle]) scale(0.31*[labelsizefactor])"/>
-	</Rule>-->
-    <Rule>
+	</Rule>
+       <Rule>
 		&maxscale_zoom13;
 		&minscale_zoom13;
-		<!--<Filter>((([icon]='soccer' or [icon]='multi') and [athletics_track] != 'yes') and [pitch_area] &gt; 3500)</Filter>-->
-        <Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
+                <Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-oval_z13.svg" transform="rotate([angle]) scale(0.19*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom14;
 		&minscale_zoom14;
-		<!--<Filter>((([icon]='soccer' or [icon]='multi') and [athletics_track] != 'yes') and [pitch_area] &gt; 3500)</Filter>-->
-        <Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-oval_z14.svg" transform="rotate([angle]) scale(0.31*[labelsizefactor])"/>
 	</Rule>
 
@@ -31,46 +29,45 @@
 	<Rule>
 		&maxscale_zoom15;
 		&minscale_zoom15;
-		<Filter>(([icon]='soccer' or [icon]='multi') and [pitch_area] &gt; 3500)</Filter>
-		<!--<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.052*[labelsizefactor])"/>-->
-        <PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-oval_z15.svg" transform="rotate([angle]) scale(0.65*[labelsizefactor])"/>
+		<Filter>(([icon]='soccer' or [icon]='multi' or [icon]='soccer_with_track' or [icon]='multi_with_track') and [pitch_area] &gt; 3500)</Filter>
+                <PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-oval_z15.svg" transform="rotate([angle]) scale(0.65*[labelsizefactor])"/>
 	</Rule>
 	
 	<!-- soccer -->
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom16;
-		<Filter>([icon]='soccer' and [pitch_area] &lt; 3500)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='soccer_with_track') and [pitch_area] &lt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.0776*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
-		<Filter>([icon]='soccer' and [pitch_area] &lt; 3500)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='soccer_with_track') and [pitch_area] &lt; 3500)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.15525*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom16;
-		<Filter>([icon]='soccer' and [pitch_area] &gt;= 3500 and [pitch_area] &lt; 10000)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='soccer_with_track') and [pitch_area] &gt;= 3500 and [pitch_area] &lt; 10000)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.1035*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
-		<Filter>([icon]='soccer' and [pitch_area] &gt;= 3500 and [pitch_area] &lt; 10000)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='soccer_with_track') and [pitch_area] &gt;= 3500 and [pitch_area] &lt; 10000)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.20*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom16;
-		<Filter>([icon]='soccer' and [pitch_area] &gt;= 10000)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='soccer_with_track') and [pitch_area] &gt;= 10000)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.12075*[labelsizefactor])"/>
 	</Rule>
 	<Rule>
 		&maxscale_zoom17;
 		&minscale_zoom17;
-		<Filter>([icon]='soccer' and [pitch_area] &gt;= 10000)</Filter>
+		<Filter>(([icon]='soccer' or [icon]='soccer_with_track') and [pitch_area] &gt;= 10000)</Filter>
 		<PointSymbolizer allow-overlap="true" ignore-placement="true" file="symbols-otm/sports-soccer.svg" transform="rotate([angle]) scale(0.2415*[labelsizefactor])"/>
 	</Rule>
 


### PR DESCRIPTION
See #11 
With a new pitchicon.sql we get additional icons ('soccer', 'tennis', 'multi' ... and now 'soccer_with_track' and 'multi_with_track').
In symbols-sport.xml there are new styles for these icons in zoom level 13 and 14. In zoom level 15 there is no icon "sports-oval-track_z15.svg" so I use "sports-oval-z15.svg" for pitches with and without tracks. 

![example Z14](https://geo.dianacht.de/bilder/otm_soccer_tracks_z14.png)
Example in that area: https://opentopomap.org/#map=14/48.17899/11.58422

**Missing**: I think @der-stefan will have more fun creating a sports-oval-track_z15.svg than I could have ;)
and don't forget to execute `psql gis < mapnik/tools/pitchicon.sql` once...