### PR TITLE
No oneway arrow for highway=construction

### DIFF
--- a/mapnik/styles-otm/bridges-fill.xml
+++ b/mapnik/styles-otm/bridges-fill.xml
@@ -429,13 +429,13 @@
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
-		<Filter>[oneway] = 'yes' and [length] &lt; 200</Filter>
+		<Filter>[oneway] = 'yes' and [length] &lt; 200 and not ([highway] = 'construction' or [highway] = 'proposed')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway.png" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
-		<Filter>[oneway] = 'yes' and [length] &gt; 200</Filter>
+		<Filter>[oneway] = 'yes' and [length] &gt; 200 and not ([highway] = 'construction' or [highway] = 'proposed')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway_long.png" />
 	</Rule>
 

--- a/mapnik/styles-otm/roads-fill.xml
+++ b/mapnik/styles-otm/roads-fill.xml
@@ -436,13 +436,13 @@
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
-		<Filter>[oneway] = 'yes' and [length] &lt; 200</Filter>
+		<Filter>[oneway] = 'yes' and [length] &lt; 200 and not ([highway] = 'construction' or [highway] = 'proposed')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway.png" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
-		<Filter>[oneway] = 'yes' and [length] &gt; 200</Filter>
+		<Filter>[oneway] = 'yes' and [length] &gt; 200 and not ([highway] = 'construction' or [highway] = 'proposed')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway_long.png" />
 	</Rule>
 	

--- a/mapnik/styles-otm/tunnels-fill.xml
+++ b/mapnik/styles-otm/tunnels-fill.xml
@@ -391,13 +391,13 @@
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
-		<Filter>[oneway] = 'yes' and [length] &lt; 200</Filter>
+		<Filter>[oneway] = 'yes' and [length] &lt; 200 and not ([highway] = 'construction' or [highway] = 'proposed')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway.png" />
 	</Rule>
 	<Rule>
 		&maxscale_zoom16;
 		&minscale_zoom17;
-		<Filter>[oneway] = 'yes' and [length] &gt; 200</Filter>
+		<Filter>[oneway] = 'yes' and [length] &gt; 200 and not ([highway] = 'construction' or [highway] = 'proposed')</Filter>
 		<LinePatternSymbolizer file="symbols-otm/oneway_long.png" />
 	</Rule>
 


### PR DESCRIPTION
As stated  [in the OSM forum](https://forum.openstreetmap.org/viewtopic.php?pid=677270#p677270) we draw arrows for (highway=construction oneway=yes) but we don't show the road...

We still would label this road, but maybe this is not a real problem and I don't want to change the simple rules in road-names-text.xml to something complicated...
