### PR TITLE
render waterway=wadi 

### DIFF
--- a/mapnik/styles-otm/waterway-lines.xml
+++ b/mapnik/styles-otm/waterway-lines.xml
@@ -79,7 +79,7 @@
 	<Rule>
 		&maxscale_zoom13;
 		&minscale_zoom17;
-		<Filter>([waterway] = 'ditch' or [waterway] = 'drain') and ([intermittent] = 'yes')</Filter>
+		<Filter>(([waterway] = 'ditch' or [waterway] = 'drain') and ([intermittent] = 'yes')) or ([waterway] = 'wadi')</Filter>
 		<LineSymbolizer stroke="#1d4dff" stroke-width="0.5" stroke-dasharray="1.5,2" />
 	</Rule>
 


### PR DESCRIPTION
waterway=wadi is marked as [deprecated in the wiki](https://wiki.openstreetmap.org/wiki/Tag%3Awaterway%3Dwadi), but it's [still widely used](https://taginfo.openstreetmap.org/tags/waterway=wadi#overview). Most of them are in areas where not a lot of mappers will change the tagging. We could render them like (waterway=stream and intermittent=yes). It's not necessary to show their names because no wadi has a name in our database and new mapped wadis should be tagged as waterway=river|stream + intermittent=yes.
![waterway=wadi](https://geo.dianacht.de/bilder/otm_wadi.png)
That area: https://opentopomap.org/#map=15/30.33582/35.41964