### PR TITLE
Add region:type to osm2pgsql style

### DIFF
--- a/mapnik/osm2pgsql/opentopomap.style
+++ b/mapnik/osm2pgsql/opentopomap.style
@@ -144,6 +144,7 @@ node,way   power_source text         linear
 node,way   public_transport text     polygon
 node,way   railway      text         linear
 node,way   ref          text         linear
+way        region:type  text         polygon
 node,way   religion     text         nocache
 node,way	resource	text		polygon
 node,way   route        text         linear


### PR DESCRIPTION
I will try to render (region=place + region:type=mountain_area|natural_area) and maybe natural=massif and some other areas. region:type=mountain_area is necessary for most parts of the alps ([Glocknergruppe](https://www.openstreetmap.org/relation/2129185)) region:type=natural_area for some other regions ([Frankenwald](https://www.openstreetmap.org/relation/3575639#map=10/50.3503/11.3400)). So it would be nice to have the column  "region:type" after the next update of the database.