### PR TITLE
moving contours below water and other layers

### DIFF
--- a/mapnik/opentopomap.xml
+++ b/mapnik/opentopomap.xml
@@ -197,6 +197,17 @@
 			&postgis-settings;
 		</Datasource>
 	</Layer>
+        
+	<Layer name="contours">
+		<StyleName>contours</StyleName>
+		<Datasource>
+			<!-- If you imported the contour lines as suggested in the HOWTO_DEM, use following:
+            <Parameter name="table">(SELECT way,ele FROM planet_osm_line) AS contours </Parameter>-->
+            <Parameter name="table">(SELECT way,ele FROM contours) AS contours </Parameter>
+			<Parameter name="dbname">contours</Parameter>
+			&postgis-settings;
+		</Datasource>
+	</Layer>
 	
 	&basemap-sea;
 	
@@ -300,17 +311,6 @@
 		<Datasource>
 			<Parameter name="table">(SELECT way,landuse,leisure,way_area FROM planet_osm_polygon) AS area </Parameter>
 			<Parameter name="dbname">gis</Parameter>
-			&postgis-settings;
-		</Datasource>
-	</Layer>
-
-	<Layer name="contours">
-		<StyleName>contours</StyleName>
-		<Datasource>
-			<!-- If you imported the contour lines as suggested in the HOWTO_DEM, use following:
-            <Parameter name="table">(SELECT way,ele FROM planet_osm_line) AS contours </Parameter>-->
-            <Parameter name="table">(SELECT way,ele FROM contours) AS contours </Parameter>
-			<Parameter name="dbname">contours</Parameter>
 			&postgis-settings;
 		</Datasource>
 	</Layer>


### PR DESCRIPTION
Many thanks to all contributors for this amazing style!

This PR prevents contour lines from being drawn over water (lakes, oceans, etc).

![contours-water](https://user-images.githubusercontent.com/8945883/49574400-66f80e80-f951-11e8-93b6-ad7b6fbb6e6a.png)
(before)

![after](https://user-images.githubusercontent.com/8945883/49576858-361ad800-f957-11e8-8e13-363796a63ea8.png)
(after)

1. This looks sloppy, like a rendering mistake.
2. Users of topo maps might think these are bathymetric contours, but they *are not*. ASTER/SRTM data is not intended for this. It includes very little underwater terrain and these patches are probably very inaccurate.
3. "Professional" topo maps style and label bathymetric contours differently from land ones. Example:
![water-contours](https://user-images.githubusercontent.com/8945883/49575736-7af13f80-f954-11e8-9ba0-9423d79fef24.png)

It would be cool and useful to include a real bathymetric layer in the future! Until then I think these land contours should not appear over water layers.

This also addresses #203 (contours over buildings).