### PR TITLE
Update pitchicon.sql

### DIFF
--- a/mapnik/tools/pitchicon.sql
+++ b/mapnik/tools/pitchicon.sql
@@ -139,7 +139,7 @@ CREATE OR REPLACE FUNCTION getpitchicon(inway geometry, sport text) RETURNS otm_
               WHERE planet_osm_line.way && ST_EXPAND(myway,trackdist/labelsizefactor) 
               AND   leisure='track' 
               AND   CASE WHEN ST_ISCLOSED(planet_osm_line.way)
-                          THEN ST_CONTAINS(ST_MakePolygon(planet_osm_line.way),myway) 
+                          THEN ST_CONTAINS(ST_MakePolygon(ST_ExteriorRing(planet_osm_line.way)),myway) 
                          ELSE FALSE 
                     END
               LIMIT 1;


### PR DESCRIPTION
Avoid errors "lwpoly_from_lwlines: shell must have at least 4 points" in getpitchicon().

This shouldn't happen, because we first check wether the track ist closed, but sometimes I get this error message while rendering. Maybe some misinterpretation of the postgresql optimizer....

It seems, this error leads to a high memory consumption of mapnik. Can't reproduce it now, because now my optimizer seems to check "st_isclosed()" before "st_contains()", but with this patch my renderd needs far less memory...

You have to do `psql gis < mapnik/tools/pitchicon.sql` once after this patch.
