### PR TITLE
switch coastlines from openstreetmapdata.com to osmdata.openstreetmap.de

### DIFF
--- a/mapnik/README.md
+++ b/mapnik/README.md
@@ -178,10 +178,10 @@ cd OpenTopoMap/mapnik
 Get the generalized water polygons from http://openstreetmapdata.com/:
 ```
 mkdir data && cd data
-wget http://data.openstreetmapdata.com/water-polygons-generalized-3857.zip
-wget http://data.openstreetmapdata.com/water-polygons-split-3857.zip
-unzip water-polygons-generalized-3857.zip
+wget https://osmdata.openstreetmap.de/download/simplified-water-polygons-split-3857.zip
+wget https://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip
 unzip water-polygons-split-3857.zip
+unzip simplified-water-polygons-split-3857.zip
 ```
 
 ## Configure Python 3 as default

--- a/mapnik/styles-otm/basemap-sea.xml
+++ b/mapnik/styles-otm/basemap-sea.xml
@@ -1,55 +1,6 @@
-<Style name="waterpolys_z1">
-	<Rule>
-		&maxscale_zoom0;
-		&minscale_zoom1;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
-<Style name="waterpolys_z2">
-	<Rule>
-		&maxscale_zoom2;
-		&minscale_zoom2;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
-<Style name="waterpolys_z3">
-	<Rule>
-		&maxscale_zoom3;
-		&minscale_zoom3;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
-<Style name="waterpolys_z4">
-	<Rule>
-		&maxscale_zoom4;
-		&minscale_zoom4;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
-<Style name="waterpolys_z5">
-	<Rule>
-		&maxscale_zoom5;
-		&minscale_zoom5;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
-<Style name="waterpolys_z6">
-	<Rule>
-		&maxscale_zoom6;
-		&minscale_zoom6;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
-<Style name="waterpolys_z7">
-	<Rule>
-		&maxscale_zoom7;
-		&minscale_zoom7;
-		<PolygonSymbolizer fill="#97d2e3" />
-	</Rule>
-</Style>
 <Style name="waterpolys_z8">
 	<Rule>
-		&maxscale_zoom8;
+		&maxscale_zoom0;
 		&minscale_zoom8;
 		<PolygonSymbolizer fill="#97d2e3" />
 	</Rule>
@@ -69,62 +20,14 @@
 	</Rule>
 </Style>
 
-<Layer name="waterpolys_z1">
-	<StyleName>waterpolys_z1</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z1</Parameter>
-	</Datasource>
-</Layer>
-<Layer name="waterpolys_z2">
-	<StyleName>waterpolys_z2</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z2</Parameter>
-	</Datasource>
-</Layer>
-<Layer name="waterpolys_z3">
-	<StyleName>waterpolys_z3</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z3</Parameter>
-	</Datasource>
-</Layer>
-<Layer name="waterpolys_z4">
-	<StyleName>waterpolys_z4</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z4</Parameter>
-	</Datasource>
-</Layer>
-<Layer name="waterpolys_z5">
-	<StyleName>waterpolys_z5</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z5</Parameter>
-	</Datasource>
-</Layer>
-<Layer name="waterpolys_z6">
-	<StyleName>waterpolys_z6</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z6</Parameter>
-	</Datasource>
-</Layer>
-<Layer name="waterpolys_z7">
-	<StyleName>waterpolys_z7</StyleName>
-	<Datasource>
-		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z7</Parameter>
-	</Datasource>
-</Layer>
 <Layer name="waterpolys_z8">
 	<StyleName>waterpolys_z8</StyleName>
 	<Datasource>
 		<Parameter name="type">shape</Parameter>
-		<Parameter name="file">data/water-polygons-generalized-3857/water_polygons_z8</Parameter>
+		<Parameter name="file">data/simplified-water-polygons-split-3857/simplified_water_polygons</Parameter>
 	</Datasource>
 </Layer>
+
 <Layer name="waterpolys">
 	<StyleName>waterpolys_z9</StyleName>
 	<StyleName>waterpolys_z11</StyleName>


### PR DESCRIPTION
Fix for #230 

openstreetmapdata.com is not longer active. We take the water-polygons from osmdata.openstreetmap.de.
For Zoom>8 there is no difference, for lower zoom level there is now only one shape file for all zoom levels, but there is no visible difference after rendering.
These are the same coastlines as used for osm carto, so we have a chance they are updated for long time.

@der-stefan these shape files are allready on the server and are regulary updated (i hope...), so checking out this style should be enough.