### PR TITLE
Change to use o5m splitter output

### DIFF
--- a/garmin/README.md
+++ b/garmin/README.md
@@ -63,12 +63,11 @@ SEA="$(pwd)/sea"
 mkdir data
 pushd data > /dev/null
 
-rm -f morocco-latest.osm.pbf
-wget "https://download.geofabrik.de/africa/morocco-latest.osm.pbf"
+wget -N "https://download.geofabrik.de/africa/morocco-latest.osm.pbf"
 
-rm -f 6324*.pbf
-java -jar $SPLITTERJAR --precomp-sea=$SEA "$(pwd)/morocco-latest.osm.pbf"
-DATA="$(pwd)/6324*.pbf"
+rm -f 6324*.o5m
+java -jar $SPLITTERJAR --precomp-sea=$SEA --output=o5m "$(pwd)/morocco-latest.osm.pbf"
+DATA="$(pwd)/6324*.o5m"
 
 popd > /dev/null
 


### PR DESCRIPTION
- Change to use o5m tile splitter output to fix
  https://github.com/der-stefan/OpenTopoMap/issues/314
- Remove rm and add use timestamps flag (`-N`) to `wget` downloading latest
  map data so only download if it has been updated