### PR TITLE
Add column otm_isolation to table planet_osm_polygon

### DIFF
--- a/mapnik/tools/update_isolations.sh
+++ b/mapnik/tools/update_isolations.sh
@@ -39,6 +39,23 @@ if [ "$column" != " otm_isolation" ] ; then
 fi
 
 #
+# Check if otm_isolation is a column of planet_osm_polygon, if not, create it
+#
+
+column=`psql -d $DBname -t -c "SELECT attname FROM pg_attribute \
+         WHERE attrelid = ( SELECT oid FROM pg_class WHERE relname = 'planet_osm_polygon' ) \
+         AND attname = 'otm_isolation';"`
+
+if [ "$column" != " otm_isolation" ] ; then
+ psql -d $DBname -c "ALTER TABLE planet_osm_polygon ADD COLUMN otm_isolation text;"
+fi
+
+#
+# Check once again. If the column doesn't exist -> EXIT
+#
+
+
+#
 # Check once again. If the column doesn't exist -> EXIT
 #
 


### PR DESCRIPTION
When i tried to setup the map i came accross the problem that the column otm_isolation  is not present in the table planet_osm_polygon. 

The layer symbols-poly in opentopomap.xml needs also the column otm_isolation.

So i deciced to add the column in the script update_isolations.sh